### PR TITLE
Force str() to os calls for Windows

### DIFF
--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -65,7 +65,7 @@ def _dat_n_samples(filename, dtype=None, n_channels=None, offset=None):
     assert dtype is not None
     item_size = np.dtype(dtype).itemsize
     offset = offset if offset else 0
-    n_samples = (op.getsize(filename) - offset) // (item_size * n_channels)
+    n_samples = (op.getsize(str(filename)) - offset) // (item_size * n_channels)
     assert n_samples >= 0
     return n_samples
 

--- a/phylib/utils/_misc.py
+++ b/phylib/utils/_misc.py
@@ -206,7 +206,7 @@ def _write_tsv(path, field_name, data):
 
 def _git_version():
     curdir = os.getcwd()
-    os.chdir(Path(__file__).parent)
+    os.chdir(str(Path(__file__).parent))
     try:
         with open(os.devnull, 'w') as fnull:
             version = ('-git-' + subprocess.check_output(


### PR DESCRIPTION
`WindowsPath` raise errors in windows when `os` calls are performed. Instead they work for `PosixPath`.
Running the newest phy version I hade to make these changes to make it run.