### PR TITLE
Olive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ docs/_build
 
 .vscode
 *.code-workspace
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - conda install pyyaml
   - conda env create python=$TRAVIS_PYTHON_VERSION
   - source activate phylib
+  - conda install pyqt
   # Dev requirements
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt

--- a/phylib/__init__.py
+++ b/phylib/__init__.py
@@ -24,7 +24,7 @@ from .utils.event import connect, unconnect, emit
 
 __author__ = 'Cyrille Rossant'
 __email__ = 'cyrille.rossant at gmail.com'
-__version__ = '2.0alpha'
+__version__ = '2.0a0'
 __version_git__ = __version__ + _git_version()
 
 

--- a/phylib/__init__.py
+++ b/phylib/__init__.py
@@ -45,7 +45,7 @@ class _Formatter(logging.Formatter):
         filename = op.splitext(op.basename(record.pathname))[0]
         record.caller = '{:s}:{:d}'.format(filename, record.lineno).ljust(20)
         message = super(_Formatter, self).format(record)
-        color_code = {'D': '37', 'I': '0', 'W': '33', 'E': '31'}.get(record.levelname, '7')
+        color_code = {'D': '90', 'I': '0', 'W': '33', 'E': '31'}.get(record.levelname, '7')
         message = '\33[%sm%s\33[0m' % (color_code, message)
         return message
 

--- a/phylib/__init__.py
+++ b/phylib/__init__.py
@@ -60,6 +60,15 @@ def add_default_handler(level='INFO', logger=logger):
     logger.addHandler(handler)
 
 
+def _add_log_file(filename):  # pragma: no cover
+    """Create a log file with DEBUG level."""
+    handler = logging.FileHandler(filename)
+    handler.setLevel(logging.DEBUG)
+    formatter = _Formatter(fmt=_logger_fmt, datefmt=_logger_date_fmt)
+    handler.setFormatter(formatter)
+    logging.getLogger('phy').addHandler(handler)
+
+
 @atexit.register
 def on_exit():  # pragma: no cover
     # Close the logging handlers.

--- a/phylib/__init__.py
+++ b/phylib/__init__.py
@@ -24,7 +24,7 @@ from .utils.event import connect, unconnect, emit
 
 __author__ = 'Cyrille Rossant'
 __email__ = 'cyrille.rossant at gmail.com'
-__version__ = '2.0a0'
+__version__ = '2.0a1'
 __version_git__ = __version__ + _git_version()
 
 

--- a/phylib/electrode/layout.py
+++ b/phylib/electrode/layout.py
@@ -21,6 +21,7 @@ from phylib.utils.color import selected_cluster_color
 #------------------------------------------------------------------------------
 
 def _iter_channel(positions):
+    """Iterate through the channel positions."""
     size = 100
     margin = 5
     boxes = _get_boxes(positions, keep_aspect_ratio=False)
@@ -36,6 +37,7 @@ def _iter_channel(positions):
 
 
 def _disk(x, y, r, c, t=0):
+    """Return a SVG disc."""
     return ('<circle cx="%.5f%%" cy="%.5f%%" '
             'r="%d" fill="%s" '
             'transform="translate(%d, 0)"'
@@ -48,7 +50,7 @@ def _rgba(rgb, a=1.):
 
 
 def _iter_disks(positions, cluster_channels=None):
-    """
+    """Iterate through the SVG dics for all channels and clusters.
 
     positions: Nx2 array
     cluster_channels: {cluster: channels}
@@ -87,6 +89,7 @@ def _iter_disks(positions, cluster_channels=None):
 
 
 def probe_layout(positions, cluster_channels):
+    """Return a probe layout in SVG, showing selected clusters on relevant channels."""
     contents = '\n'.join(_iter_disks(positions, cluster_channels))
     return """
     <svg style="background: black; width:100%; height:100%;">

--- a/phylib/electrode/layout.py
+++ b/phylib/electrode/layout.py
@@ -44,7 +44,7 @@ def _disk(x, y, r, c, t=0):
 
 def _rgba(rgb, a=1.):
     r, g, b = rgb
-    return 'rgba(%d, %d, %d, %.3f)' % (r, g, b, a)
+    return 'rgba(%d, %d, %d, %.3f)' % (255 * r, 255 * g, 255 * b, a)
 
 
 def _iter_disks(positions, cluster_channels=None):
@@ -55,7 +55,7 @@ def _iter_disks(positions, cluster_channels=None):
 
     """
 
-    color_masked = _rgba((128,) * 3, 1.)
+    color_masked = _rgba((.5, .5, .5), 1.)
     color_umasked = lambda clu: _rgba(selected_cluster_color(clu)[:3], 1)
 
     size_masked = 5

--- a/phylib/electrode/mea.py
+++ b/phylib/electrode/mea.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import numpy as np
 
 from phylib.utils._types import _as_array
-from phylib.utils._misc import _read_python
+from phylib.utils._misc import read_python
 
 
 #------------------------------------------------------------------------------
@@ -88,7 +88,7 @@ def load_probe(name_or_path):
         path = Path(__file__).parent / ('probes/%s.prb' % name_or_path)
     if not path.exists():
         raise IOError("The probe `{}` cannot be found.".format(name_or_path))
-    return MEA(probe=_read_python(path))
+    return MEA(probe=read_python(path))
 
 
 def list_probes():

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -152,18 +152,25 @@ class EphysAlfCreator(object):
             path = Path(path)
             dst_path = self.out_path / ('ephys.raw' + path.suffix)
             _symlink_if_possible(path, dst_path)
+            # Meta file attached to raw data can be copied as it's small
+            meta_file = path.parent / (path.stem + '.meta')
+            if meta_file.exists():
+                shutil.copyfile(meta_file, self.out_path / 'ephys.raw.meta')
 
     def symlink_lfp_data(self):
         """Symlink the LFP data file."""
         # LFP data file.
         # TODO: support for different file extensions?
-        lfp_path = _find_file_with_ext(self.dir_path, '.lf.bin')
-        if not lfp_path:  # pragma: no cover
+        lfp_path = Path(str(self.model.dat_path).replace('.ap.bin', '.lf.bin'))
+        if not lfp_path.exists():  # pragma: no cover
             logger.info("No LFP file, skipping symlinking.")
             return
         dst_path = self.out_path / ('lfp.raw' + lfp_path.suffix)
         _symlink_if_possible(lfp_path, dst_path)
-
+        # Meta file attached to raw data can be copied
+        meta_file = lfp_path .parent / (lfp_path.stem + '.meta')
+        if meta_file.exists():
+            shutil.copyfile(meta_file, self.out_path / 'lfp.raw.meta')
     # File creation
     # -------------------------------------------------------------------------
 

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -14,7 +14,7 @@ import shutil
 
 import numpy as np
 
-from phylib.utils._misc import _read_tsv, _ensure_dir_exists
+from phylib.utils._misc import _read_tsv_simple, _ensure_dir_exists
 from phylib.io.array import _spikes_per_cluster, select_spikes, _unique, grouped_mean, _index_of
 
 logger = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ def _load(path):
     if path.endswith('.npy'):
         return np.load(path)
     elif path.endswith(('.csv', '.tsv')):
-        return _read_tsv(path)[1]  # the function returns a tuple (field, data)
+        return _read_tsv_simple(path)[1]  # the function returns a tuple (field, data)
     elif path.endswith('.bin'):
         # TODO: configurable dtype
         return np.fromfile(path, np.int16)

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -143,8 +143,6 @@ class EphysAlfCreator(object):
 
         # Copy and symlink files.
         self.copy_files()
-        self.symlink_raw_data()
-        self.symlink_lfp_data()
 
         # New files.
         self.make_spike_times()
@@ -162,6 +160,7 @@ class EphysAlfCreator(object):
                 # ks2 outputs vectors as multidimensional arrays. If there is no distinction
                 # for Matlab, there is one in Numpy
                 if len(h['shape']) == 2 and h['shape'][-1] == 1:
+                    print(fn0, fn1)
                     d = np.load(self.dir_path / fn0)
                     np.save(self.out_path / fn1, d.squeeze())
                     continue

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -114,13 +114,15 @@ def _load(path):
 #------------------------------------------------------------------------------
 
 class EphysAlfCreator(object):
+    """Class for converting a dataset in KS/phy format into ALF."""
+
     def __init__(self, model):
         self.model = model
         self.dir_path = Path(model.dir_path)
         self.spc = _spikes_per_cluster(model.spike_clusters)
 
     def convert(self, out_path):
-        """Convert from phy/KS format to ALF."""
+        """Convert from KS/phy format to ALF."""
         logger.info("Converting dataset to ALF.")
         self.out_path = Path(out_path)
         if self.out_path.resolve() == self.dir_path.resolve():
@@ -138,10 +140,12 @@ class EphysAlfCreator(object):
         self.make_mean_waveforms()
 
     def copy_files(self):
+        """Make the file renames (actually copies into a new directory)."""
         for fn0, fn1 in _FILE_RENAMES:
             _copy_if_possible(self.dir_path / fn0, self.out_path / fn1)
 
     def symlink_raw_data(self):
+        """Symlink the raw data files."""
         # Raw data files.
         assert isinstance(self.model.dat_path, (list, tuple))
         for path in self.model.dat_path:
@@ -150,6 +154,7 @@ class EphysAlfCreator(object):
             _symlink_if_possible(path, dst_path)
 
     def symlink_lfp_data(self):
+        """Symlink the LFP data file."""
         # LFP data file.
         # TODO: support for different file extensions?
         lfp_path = _find_file_with_ext(self.dir_path, '.lf.bin')
@@ -163,6 +168,7 @@ class EphysAlfCreator(object):
     # -------------------------------------------------------------------------
 
     def _save_npy(self, filename, arr):
+        """Save an array into a .npy file."""
         np.save(self.out_path / filename, arr)
 
     def make_spike_times(self):
@@ -221,6 +227,7 @@ class EphysAlfCreator(object):
         self._save_npy('clusters.depths.npy', clusters_depths)
 
     def make_mean_waveforms(self):
+        """Make the mean waveforms file."""
         spike_ids = select_spikes(
             cluster_ids=self.cluster_ids,
             max_n_spikes_per_cluster=100,

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -42,11 +42,16 @@ _FILE_RENAMES = [
     ('amplitudes.npy', 'spikes.amps.npy'),
     ('channel_positions.npy', 'channels.sitePositions.npy'),
     ('templates.npy', 'clusters.templateWaveforms.npy'),
+    ('cluster_Amplitude.tsv', 'clusters.amps.tsv'),
     ('channel_map.npy', 'channels.rawRow.npy'),
     ('spike_templates.npy', 'ks2/spikes.clusters.npy'),
     ('cluster_ContamPct.tsv', 'ks2/clusters.ContamPct.tsv'),
     ('cluster_group.tsv', 'ks2/clusters.phyAnnotation.tsv'),
     ('cluster_KSLabel.tsv', 'ks2/clusters.group.tsv'),
+]
+
+FILE_DELETES = [
+    'temp_wh.dat',  # potentially large file that will clog the servers
 ]
 
 
@@ -135,14 +140,22 @@ class EphysAlfCreator(object):
         # New files.
         self.make_spike_times()
         self.make_cluster_waveforms()
-        self.make_cluster_amps()
         self.make_depths()
         self.make_mean_waveforms()
+
+        # Clean up
+        self.rm_files()
 
     def copy_files(self):
         """Make the file renames (actually copies into a new directory)."""
         for fn0, fn1 in _FILE_RENAMES:
             _copy_if_possible(self.dir_path / fn0, self.out_path / fn1)
+
+    def rm_files(self):
+        for fn0 in FILE_DELETES:
+            fn = self.dir_path.joinpath(fn0)
+            if fn.exists():
+                fn.unlink()
 
     def symlink_raw_data(self):
         """Symlink the raw data files."""
@@ -183,15 +196,6 @@ class EphysAlfCreator(object):
         *samples*, and not in seconds."""
         self._save_npy('spikes.times.npy', self.model.spike_times)
 
-    def make_cluster_amps(self):
-        """ Ks2 saves cluster amplitudes in tsv, convert to npy """
-        tsv_file = self.dir_path / 'cluster_Amplitude.tsv'
-        pass
-        # data = np.genfromtxt(fname=tsv_file, delimiter="\t", skip_header=1)
-        # assert(data[0, 0] == 0)
-        # assert(data[-1, 0] == data.shape[0]
-        # np.save(self.out_path / 'clusters.amps.tsv', data[:, 1].astype('float32'))
-        
     def make_cluster_waveforms(self):
         """Return the channel index with the highest template amplitude, for
         every template."""
@@ -249,28 +253,9 @@ class EphysAlfCreator(object):
             max_n_spikes_per_cluster=100,
             spikes_per_cluster=lambda clu: self.spc[clu],
             subset='random')
-        waveforms = self.model.get_waveforms(spike_ids[0:1], np.arange(self.model.n_channels))
+        waveforms = self.model.get_waveforms(spike_ids, np.arange(self.model.n_channels))
         try:
             mean_waveforms = grouped_mean(waveforms, self.model.spike_clusters[spike_ids])
             self._save_npy('clusters.meanWaveforms.npy', mean_waveforms)
         except IndexError as e:  # pragma: no cover
             logger.warning("Failed to create the mean waveforms file: %s.", e)
-
-
-        self.model.spike_clusters
-
-        ##
-        
-        # initialize the mean_waveform array: [nc, nsw, nch]
-        mean_waveforms = np.zeros((np.max(self.model.spike_clusters) + 1,
-                                   self.model.n_samples_templates,
-                                   self.model.n_channels))
-        
-        is_ = np.argsort(self.model.spike_times).astype('int32')
-        st = np.round(self.model.spike_times[is_] * self.model.sample_rate).astype('int32')
-        
-        # an issue here is that it won't work if data is in several files
-        self.model.traces.arrs[0]
-        
-        
-        

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -45,10 +45,10 @@ _FILE_RENAMES = [  # file_in, file_out, squeeze (bool to squeeze vector from mat
     ('templates.npy', 'clusters.templateWaveforms.npy', False),
     ('cluster_Amplitude.tsv', 'clusters.amps.tsv', False),
     ('channel_map.npy', 'channels.rawRow.npy', True),
-    ('spike_templates.npy', 'ks2/spikes.clusters.npy', True),
-    ('cluster_ContamPct.tsv', 'ks2/clusters.ContamPct.tsv', False),
-    ('cluster_group.tsv', 'ks2/clusters.phyAnnotation.tsv', False),
-    ('cluster_KSLabel.tsv', 'ks2/clusters.group.tsv', False),
+    # ('spike_templates.npy', 'ks2/spikes.clusters.npy', True),
+    # ('cluster_ContamPct.tsv', 'ks2/clusters.ContamPct.tsv', False),
+    # ('cluster_group.tsv', 'ks2/clusters.phyAnnotation.tsv', False),
+    # ('cluster_KSLabel.tsv', 'ks2/clusters.group.tsv', False),
 ]
 
 FILE_DELETES = [

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -42,7 +42,6 @@ _FILE_RENAMES = [
     ('amplitudes.npy', 'spikes.amps.npy'),
     ('channel_positions.npy', 'channels.sitePositions.npy'),
     ('templates.npy', 'clusters.templateWaveforms.npy'),
-    ('cluster_Amplitude.tsv', 'clusters.amps.tsv'),
     ('channel_map.npy', 'channels.rawRow.npy'),
     ('spike_templates.npy', 'ks2/spikes.clusters.npy'),
     ('cluster_ContamPct.tsv', 'ks2/clusters.ContamPct.tsv'),
@@ -136,6 +135,7 @@ class EphysAlfCreator(object):
         # New files.
         self.make_spike_times()
         self.make_cluster_waveforms()
+        self.make_cluster_amps()
         self.make_depths()
         self.make_mean_waveforms()
 
@@ -183,6 +183,15 @@ class EphysAlfCreator(object):
         *samples*, and not in seconds."""
         self._save_npy('spikes.times.npy', self.model.spike_times)
 
+    def make_cluster_amps(self):
+        """ Ks2 saves cluster amplitudes in tsv, convert to npy """
+        tsv_file = self.dir_path / 'cluster_Amplitude.tsv'
+        pass
+        # data = np.genfromtxt(fname=tsv_file, delimiter="\t", skip_header=1)
+        # assert(data[0, 0] == 0)
+        # assert(data[-1, 0] == data.shape[0]
+        # np.save(self.out_path / 'clusters.amps.tsv', data[:, 1].astype('float32'))
+        
     def make_cluster_waveforms(self):
         """Return the channel index with the highest template amplitude, for
         every template."""
@@ -240,9 +249,28 @@ class EphysAlfCreator(object):
             max_n_spikes_per_cluster=100,
             spikes_per_cluster=lambda clu: self.spc[clu],
             subset='random')
-        waveforms = self.model.get_waveforms(spike_ids, np.arange(self.model.n_channels))
+        waveforms = self.model.get_waveforms(spike_ids[0:1], np.arange(self.model.n_channels))
         try:
             mean_waveforms = grouped_mean(waveforms, self.model.spike_clusters[spike_ids])
             self._save_npy('clusters.meanWaveforms.npy', mean_waveforms)
         except IndexError as e:  # pragma: no cover
             logger.warning("Failed to create the mean waveforms file: %s.", e)
+
+
+        self.model.spike_clusters
+
+        ##
+        
+        # initialize the mean_waveform array: [nc, nsw, nch]
+        mean_waveforms = np.zeros((np.max(self.model.spike_clusters) + 1,
+                                   self.model.n_samples_templates,
+                                   self.model.n_channels))
+        
+        is_ = np.argsort(self.model.spike_times).astype('int32')
+        st = np.round(self.model.spike_times[is_] * self.model.sample_rate).astype('int32')
+        
+        # an issue here is that it won't work if data is in several files
+        self.model.traces.arrs[0]
+        
+        
+        

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -14,7 +14,7 @@ import shutil
 
 import numpy as np
 
-from phylib.utils._misc import _read_tsv_simple, _ensure_dir_exists
+from phylib.utils._misc import _read_tsv_simple, ensure_dir_exists
 from phylib.io.array import _spikes_per_cluster, select_spikes, _unique, grouped_mean, _index_of
 
 logger = logging.getLogger(__name__)
@@ -60,7 +60,7 @@ def _create_if_possible(path, new_path):
     if Path(new_path).exists():  # pragma: no cover
         logger.warning("Path %s already exists, skipping.", new_path)
         return False
-    _ensure_dir_exists(new_path.parent)
+    ensure_dir_exists(new_path.parent)
     return True
 
 

--- a/phylib/io/datasets.py
+++ b/phylib/io/datasets.py
@@ -10,7 +10,7 @@ import hashlib
 import logging
 from pathlib import Path
 
-from phylib.utils._misc import _ensure_dir_exists, phy_config_dir
+from phylib.utils._misc import ensure_dir_exists, phy_config_dir
 from phylib.utils.event import ProgressReporter
 
 
@@ -134,7 +134,7 @@ def download_test_file(name, config_dir=None, force=False):
     config_dir = Path(config_dir or phy_config_dir())
     path = config_dir / 'test_data' / name
     # Ensure the directory exists.
-    _ensure_dir_exists(path.parent)
+    ensure_dir_exists(path.parent)
     if not force and path.exists():
         return path
     url = _BASE_URL + name

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -22,7 +22,7 @@ from .array import (
 )
 from phylib.traces import WaveformLoader
 from phylib.utils import Bunch
-from phylib.utils._misc import _write_tsv, _read_tsv
+from phylib.utils._misc import _write_tsv_simple, _read_tsv_simple
 
 
 logger = logging.getLogger(__name__)
@@ -63,12 +63,12 @@ def load_metadata(filename):
     Return (field_name, dictionary).
 
     """
-    return _read_tsv(filename)
+    return _read_tsv_simple(filename)
 
 
 def save_metadata(filename, field_name, metadata):
     """Save metadata in a CSV file."""
-    return _write_tsv(filename, field_name, metadata)
+    return _write_tsv_simple(filename, field_name, metadata)
 
 
 def _dat_n_samples(filename, dtype=None, n_channels=None, offset=None):
@@ -345,10 +345,15 @@ class TemplateModel(object):
 
     def _load_metadata(self):
         """Load cluster metadata from all CSV/TSV files in the data directory."""
+        # Files to exclude.
+        excluded_names = ('cluster_info',)
+        # Get all CSV/TSV files in the directory.
         files = list(self.dir_path.glob('*.csv'))
         files.extend(self.dir_path.glob('*.tsv'))
         metadata = {}
         for filename in files:
+            if filename.stem in excluded_names:
+                continue
             logger.debug("Load `%s`.", filename)
             try:
                 field_name, values = load_metadata(filename)

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -269,8 +269,11 @@ class TemplateModel(object):
         self.channel_positions = self._load_channel_positions()
         assert self.channel_positions.shape == (nc, 2)
 
-        self.channel_vertical_order = np.argsort(self.channel_positions[:, 1],
-                                                 kind='mergesort')
+        self.channel_shanks = self._load_channel_shanks()
+        if self.channel_shanks is not None:
+            assert self.channel_shanks.shape == (nc,)
+
+        self.channel_vertical_order = np.argsort(self.channel_positions[:, 1], kind='mergesort')
 
         # Templates.
         self.sparse_templates = self._load_templates()
@@ -278,8 +281,7 @@ class TemplateModel(object):
         self.n_samples_templates = self.sparse_templates.data.shape[1]
         self.n_channels_loc = self.sparse_templates.data.shape[2]
         if self.sparse_templates.cols is not None:
-            assert self.sparse_templates.cols.shape == (self.n_templates,
-                                                        self.n_channels_loc)
+            assert self.sparse_templates.cols.shape == (self.n_templates, self.n_channels_loc)
 
         # Whitening.
         try:
@@ -409,6 +411,16 @@ class TemplateModel(object):
         out = np.atleast_2d(out)
         assert out.ndim == 2
         return out
+
+    def _load_channel_shanks(self):
+        try:
+            path = self._find_path('channel_shanks.npy')
+            out = self._read_array(path).reshape((-1,))
+            assert out.ndim == 1
+            return out
+        except IOError:
+            logger.debug("No channel shank file found.")
+            return
 
     def _load_traces(self, channel_map=None):
         if not self.dat_path:

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -385,7 +385,7 @@ class TemplateModel(object):
             # The part after spike_***
             n = filename.stem[6:]
             # Skip known files.
-            if n in ('clusters', 'templates', 'samples', 'times'):
+            if n in ('clusters', 'templates', 'samples', 'times', 'amplitudes'):
                 continue
             try:
                 arr = self._read_array(filename)

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -345,11 +345,14 @@ class TemplateModel(object):
 
         # Features.
         self.sparse_features = self._load_features()
+        self.features = self.sparse_features.data if self.sparse_features else None
         if self.sparse_features is not None:
             self.n_features_per_channel = self.sparse_features.data.shape[2]
 
         # Template features.
         self.sparse_template_features = self._load_template_features()
+        self.template_features = (
+            self.sparse_template_features.data if self.sparse_template_features else None)
 
         # Spike attributes.
         self.spike_attributes = self._load_spike_attributes()

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -877,7 +877,7 @@ def _make_abs_path(p, dir_path):
 
 
 def get_template_params(params_path):
-    """Get a dictionary of parameters from a params.py file."""
+    """Get a dictionary of parameters from a `params.py` file."""
     params_path = Path(params_path)
 
     params = read_python(params_path)
@@ -896,5 +896,5 @@ def get_template_params(params_path):
 
 
 def load_model(params_path):
-    """Return a TemplateModel instance from a path to a params.py file."""
+    """Return a TemplateModel instance from a path to a `params.py` file."""
     return TemplateModel(**get_template_params(params_path))

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -536,7 +536,12 @@ class TemplateModel(object):
             return
 
         try:
-            path = self._find_path('template_ind.npy', 'templates_ind.npy')
+            # WARNING: KS2 saves templates_ind.npy (with an s), and note template_ind.npy,
+            # so that file is not taken into account here.
+            # That means templates.npy is considered as a dense array.
+            # Proper fix would be to save templates.npy as a true sparse array, with proper
+            # template_ind.npy (without an s).
+            path = self._find_path('template_ind.npy')
             cols = self._read_array(path)
             cols = np.atleast_2d(cols)
             assert cols.ndim == 2
@@ -696,6 +701,7 @@ class TemplateModel(object):
         data, cols = self.sparse_templates.data, self.sparse_templates.cols
         assert cols is not None
         template_w, channel_ids = data[template_id], cols[template_id]
+        channel_ids = channel_ids.astype(np.uint32)
         # Remove unused channels = -1.
         used = channel_ids != -1
         template_w = template_w[:, used]

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -183,8 +183,8 @@ def _find_first_existing_path(*paths, multiple_ok=True):
 class TemplateModel(object):
     """Object holding all data of a KiloSort/phy dataset."""
 
-    n_closest_channels = 16
-    amplitude_threshold = .25
+    n_closest_channels = 12
+    amplitude_threshold = 0
 
     def __init__(self, dat_path=None, **kwargs):
         if not dat_path:  # pragma: no cover

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -116,14 +116,15 @@ def get_closest_channels(channel_positions, channel_index, n=None):
 def from_sparse(data, cols, channel_ids):
     """Convert a sparse structure into a dense one.
 
-    Arguments:
+    Parameters
+    ----------
 
-    data : array
+    data : array-like
         A (n_spikes, n_channels_loc, ...) array with the data.
-    cols : array
+    cols : array-like
         A (n_spikes, n_channels_loc) array with the channel indices of
         every row in data.
-    channel_ids : array
+    channel_ids : array-like
         List of requested channel ids (columns).
 
     """
@@ -181,9 +182,36 @@ def _find_first_existing_path(*paths, multiple_ok=True):
 #------------------------------------------------------------------------------
 
 class TemplateModel(object):
-    """Object holding all data of a KiloSort/phy dataset."""
+    """Object holding all data of a KiloSort/phy dataset.
 
+    Constructor
+    -----------
+
+    dat_path : str, Path, or list
+        Path to the raw data files.
+    dir_path : str or Path
+        Path to the dataset directory
+    dtype : NumPy dtype
+        Data type of the raw data file
+    offset : int
+        Header offset of the binary file
+    n_channels_dat : int
+        Number of channels in the dat file
+    sample_rate : float
+        Sampling rate of the data file.
+    filter_order : int
+        Order of the filter used for waveforms
+    hp_filtered : bool
+        Whether the raw data file is already high-pass filtered. In that case, disable the
+        filtering for the waveform extraction.
+
+    """
+
+    """Number of closest channels used for templates."""
     n_closest_channels = 12
+
+    """Fraction of the peak amplitude required by the closest channels to be kept as best
+    channels."""
     amplitude_threshold = 0
 
     def __init__(self, dat_path=None, **kwargs):
@@ -307,12 +335,13 @@ class TemplateModel(object):
         # Number of time samples in the templates.
         nsw = self.n_samples_templates
         if self.traces is not None:
-            return WaveformLoader(traces=self.traces,
-                                  spike_samples=self.spike_samples,
-                                  n_samples_waveforms=nsw,
-                                  filter_order=self.filter_order,
-                                  sample_rate=self.sample_rate,
-                                  )
+            return WaveformLoader(
+                traces=self.traces,
+                spike_samples=self.spike_samples,
+                n_samples_waveforms=nsw,
+                filter_order=self.filter_order,
+                sample_rate=self.sample_rate,
+            )
 
     def _find_path(self, *names, multiple_ok=True):
         return _find_first_existing_path(

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -687,14 +687,15 @@ class TemplateModel(object):
         else:
             return self._get_template_dense(template_id, channel_ids=channel_ids)
 
-    def get_waveforms(self, spike_ids, channel_ids):
+    def get_waveforms(self, spike_ids, channel_ids=None):
         """Return spike waveforms on specified channels."""
         if self.waveform_loader is None:
             return
         out = self.waveform_loader.get(spike_ids, channel_ids)
         assert out.dtype in (np.float32, np.float64)
         assert out.shape[0] == len(spike_ids)
-        assert out.shape[2] == len(channel_ids)
+        if channel_ids is not None:
+            assert out.shape[2] == len(channel_ids)
         return out
 
     def get_features(self, spike_ids, channel_ids):

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -252,7 +252,8 @@ class TemplateModel(object):
         ns, = self.n_spikes, = self.spike_times.shape
 
         self.amplitudes = self._load_amplitudes()
-        assert self.amplitudes.shape == (ns,)
+        if self.amplitudes is not None:
+            assert self.amplitudes.shape == (ns,)
 
         self.spike_templates = self._load_spike_templates()
         assert self.spike_templates.shape == (ns,)
@@ -438,9 +439,13 @@ class TemplateModel(object):
         return traces
 
     def _load_amplitudes(self):
-        out = self._read_array(self._find_path('amplitudes.npy', 'spikes.amps.npy'))
-        assert out.ndim == 1
-        return out
+        try:
+            out = self._read_array(self._find_path('amplitudes.npy', 'spikes.amps.npy'))
+            assert out.ndim == 1
+            return out
+        except IOError:
+            logger.debug("No amplitude file found.")
+            return
 
     def _load_spike_templates(self):
         path = self._find_path('spike_templates.npy', 'ks2/spikes.clusters.npy')

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -187,10 +187,10 @@ class TemplateModel(object):
     Constructor
     -----------
 
-    dat_path : str, Path, or list
-        Path to the raw data files.
     dir_path : str or Path
         Path to the dataset directory
+    dat_path : str, Path, or list
+        Path to the raw data files.
     dtype : NumPy dtype
         Data type of the raw data file
     offset : int
@@ -214,20 +214,19 @@ class TemplateModel(object):
     channels."""
     amplitude_threshold = 0
 
-    def __init__(self, dat_path=None, **kwargs):
-        if not dat_path:  # pragma: no cover
-            self.dat_path = None
-            self.dir_path = Path.cwd()
-        else:
-            if not isinstance(dat_path, (list, tuple)):
-                dat_path = [dat_path]
-            assert isinstance(dat_path, (list, tuple))
-            dat_path = [Path(_).resolve() for _ in dat_path]
-            self.dir_path = dat_path[0].parent
-            self.dat_path = dat_path
+    def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
+
+        # Set dir_path.
         self.dir_path = Path(self.dir_path).resolve()
         assert isinstance(self.dir_path, Path)
+        assert self.dir_path.exists()
+
+        # Set dat_path.
+        if not isinstance(self.dat_path, (list, tuple)):
+            self.dat_path = [self.dat_path]
+        assert isinstance(self.dat_path, (list, tuple))
+        self.dat_path = [Path(_).resolve() for _ in self.dat_path]
 
         self.dtype = getattr(self, 'dtype', np.int16)
         self.sample_rate = float(self.sample_rate)
@@ -875,8 +874,8 @@ def get_template_params(params_path):
     if 'dir_path' not in params:
         params['dir_path'] = params_path.parent
     params['dir_path'] = Path(params['dir_path'])
-    assert params['dir_path'].exists()
     assert params['dir_path'].is_dir()
+    assert params['dir_path'].exists()
     return params
 
 

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -621,6 +621,11 @@ class TemplateModel(object):
         # Find N closest channels.
         close_channels = get_closest_channels(
             self.channel_positions, best_channel, self.n_closest_channels)
+        # Restrict to the channels belonging to the best channel's shank.
+        if self.channel_shanks is not None:
+            shank = self.channel_shanks[best_channel]  # shank of best channel
+            channels_on_shank = np.nonzero(self.channel_shanks == shank)[0]
+            close_channels = np.intersect1d(close_channels, channels_on_shank)
         # Keep the intersection.
         channel_ids = np.intersect1d(peak_channels, close_channels)
         # Order the channels by decreasing amplitude.

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -621,7 +621,7 @@ class TemplateModel(object):
         best_channel = np.argmax(amplitude)
         max_amp = amplitude[best_channel]
         # Find the channels X% peak.
-        peak_channels = np.nonzero(amplitude > self.amplitude_threshold * max_amp)[0]
+        peak_channels = np.nonzero(amplitude >= self.amplitude_threshold * max_amp)[0]
         # Find N closest channels.
         close_channels = get_closest_channels(
             self.channel_positions, best_channel, self.n_closest_channels)

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -22,8 +22,7 @@ from .array import (
 )
 from phylib.traces import WaveformLoader
 from phylib.utils import Bunch
-from phylib.utils._misc import _write_tsv_simple, _read_tsv_simple
-
+from phylib.utils._misc import _write_tsv_simple, _read_tsv_simple, read_python
 
 logger = logging.getLogger(__name__)
 
@@ -726,3 +725,25 @@ class TemplateModel(object):
 
         assert template_features.shape[0] == ns
         return template_features
+
+
+def get_template_params(params_path):
+    """Get a dictionary of parameters from a params.py file."""
+    params_path = Path(params_path)
+
+    params = read_python(params_path)
+    if isinstance(params['dat_path'], str):
+        params['dat_path'] = [params['dat_path']]
+    params['dat_path'] = [Path(_) for _ in params['dat_path']]
+    params['dtype'] = np.dtype(params['dtype'])
+    if 'dir_path' not in params:
+        params['dir_path'] = params_path.parent
+    params['dir_path'] = Path(params['dir_path'])
+    assert params['dir_path'].exists()
+    assert params['dir_path'].is_dir()
+    return params
+
+
+def load_model(params_path):
+    """Return a TemplateModel instance from a path to a params.py file."""
+    return TemplateModel(**get_template_params(params_path))

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -90,10 +90,10 @@ def load_raw_data(path=None, n_channels_dat=None, dtype=None, offset=None):
         return
     path = Path(path)
     if not path.exists():
+        logger.warning("Path %s does not exist, trying ephys.raw filename.", path)
         path = path.parent / ('ephys.raw' + path.suffix)
         if not path.exists():
-            logger.warning(
-                "Error while loading data: File `%s` not found.", path)
+            logger.warning("Error while loading data: File `%s` not found.", path)
             return None
     assert path.exists()
     logger.debug("Loading traces at `%s`.", path)

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -862,20 +862,31 @@ class TemplateModel(object):
         np.save(path, out)
 
 
+def _make_abs_path(p, dir_path):
+    p = Path(p)
+    if not op.isabs(p):
+        p = dir_path / p
+    if not p.exists():
+        logger.warning("File %s does not exist.", p)
+    return p
+
+
 def get_template_params(params_path):
     """Get a dictionary of parameters from a params.py file."""
     params_path = Path(params_path)
 
     params = read_python(params_path)
-    if isinstance(params['dat_path'], str):
-        params['dat_path'] = [params['dat_path']]
-    params['dat_path'] = [Path(_) for _ in params['dat_path']]
     params['dtype'] = np.dtype(params['dtype'])
+
     if 'dir_path' not in params:
         params['dir_path'] = params_path.parent
     params['dir_path'] = Path(params['dir_path'])
     assert params['dir_path'].is_dir()
     assert params['dir_path'].exists()
+
+    if isinstance(params['dat_path'], str):
+        params['dat_path'] = [params['dat_path']]
+    params['dat_path'] = [_make_abs_path(_, params['dir_path']) for _ in params['dat_path']]
     return params
 
 

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -278,7 +278,7 @@ class TemplateModel(object):
         # Templates.
         self.sparse_templates = self._load_templates()
         self.n_templates = self.sparse_templates.data.shape[0]
-        self.n_samples_templates = self.sparse_templates.data.shape[1]
+        self.n_samples_waveforms = self.sparse_templates.data.shape[1]
         self.n_channels_loc = self.sparse_templates.data.shape[2]
         if self.sparse_templates.cols is not None:
             assert self.sparse_templates.cols.shape == (self.n_templates, self.n_channels_loc)
@@ -335,7 +335,7 @@ class TemplateModel(object):
 
     def _create_waveform_loader(self):
         # Number of time samples in the templates.
-        nsw = self.n_samples_templates
+        nsw = self.n_samples_waveforms
         if self.traces is not None:
             return WaveformLoader(
                 traces=self.traces,
@@ -832,20 +832,6 @@ class TemplateModel(object):
         return self.get_waveforms(spike_ids, channel_ids)
 
     #--------------------------------------------------------------------------
-    # Metadata methods
-    #--------------------------------------------------------------------------
-
-    @property
-    def metadata_fields(self):
-        """List of metadata fields."""
-        return sorted(self.metadata)
-
-    def get_metadata(self, name):
-        """Return a dictionary {cluster_id: value} for a cluster metadata
-        field."""
-        return self.metadata.get(name, {})
-
-    #--------------------------------------------------------------------------
     # Saving methods
     #--------------------------------------------------------------------------
 
@@ -868,7 +854,7 @@ class TemplateModel(object):
         """Save the mean waveforms as a single array."""
         path = self.dir_path / 'clusters.meanWaveforms.npy'
         n_clusters = len(mean_waveforms)
-        out = np.zeros((n_clusters, self.n_samples_templates, self.n_channels))
+        out = np.zeros((n_clusters, self.n_samples_waveforms, self.n_channels))
         for i, cluster_id in enumerate(sorted(mean_waveforms)):
             b = mean_waveforms[cluster_id]
             if b.data is not None:

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -591,7 +591,7 @@ class TemplateModel(object):
         assert template.shape[1] == len(channel_ids)
         # Compute the amplitude and the channel with max amplitude.
         amplitude = template.max(axis=0) - template.min(axis=0)
-        best_channel = np.argmax(amplitude)
+        best_channel = channel_ids[np.argmax(amplitude)]
         b = Bunch(template=template,
                   amplitude=amplitude,
                   best_channel=best_channel,

--- a/phylib/io/tests/conftest.py
+++ b/phylib/io/tests/conftest.py
@@ -59,7 +59,7 @@ def _remove(path):
 
 
 @fixture(scope='function', params=('dense', 'sparse', 'misc'))
-def template_path(tempdir, request):
+def template_path_full(tempdir, request):
     # Download the dataset.
     paths = list(map(download_test_file, _FILES))
     # Copy the dataset to a temporary directory.
@@ -94,6 +94,25 @@ def template_path(tempdir, request):
 
     template_path = tempdir / paths[0].name
     return template_path
+
+
+@fixture(scope='function')
+def template_path(tempdir, request):
+    # Download the dataset.
+    paths = list(map(download_test_file, _FILES))
+    # Copy the dataset to a temporary directory.
+    for path in paths:
+        to_path = tempdir / path.name
+        logger.debug("Copying file to %s.", to_path)
+        shutil.copy(path, to_path)
+
+    template_path = tempdir / paths[0].name
+    return template_path
+
+
+@fixture
+def template_model_full(template_path_full):
+    return load_model(template_path_full)
 
 
 @fixture

--- a/phylib/io/tests/conftest.py
+++ b/phylib/io/tests/conftest.py
@@ -86,6 +86,9 @@ def _make_dataset(tempdir, param='dense', has_spike_attributes=True):
         _remove(tempdir / 'template_features.npy')
         _remove(tempdir / 'pc_features.npy')
         _remove(tempdir / 'channel_shanks.npy')
+        _remove(tempdir / 'amplitudes.npy')
+        _remove(tempdir / 'whitening_mat.npy')
+        _remove(tempdir / 'whitening_mat_inv.npy')
         _remove(tempdir / 'sim_binary.dat')
 
     # Spike attributes.

--- a/phylib/io/tests/conftest.py
+++ b/phylib/io/tests/conftest.py
@@ -12,8 +12,8 @@ import shutil
 import numpy as np
 from pytest import fixture
 
-from phylib.utils._misc import read_python, write_text
-from ..model import TemplateModel, write_array
+from phylib.utils._misc import write_text
+from ..model import load_model, write_array
 from phylib.io.datasets import download_test_file
 
 logger = logging.getLogger(__name__)
@@ -98,8 +98,4 @@ def template_path(tempdir, request):
 
 @fixture
 def template_model(template_path):
-    params = read_python(template_path)
-    params['dat_path'] = template_path.parent / params['dat_path']
-    params['dir_path'] = template_path.parent
-    model = TemplateModel(**params)
-    return model
+    return load_model(template_path)

--- a/phylib/io/tests/conftest.py
+++ b/phylib/io/tests/conftest.py
@@ -12,7 +12,7 @@ import shutil
 import numpy as np
 from pytest import fixture
 
-from phylib.utils._misc import _read_python, _write_text
+from phylib.utils._misc import read_python, write_text
 from ..model import TemplateModel, write_array
 from phylib.io.datasets import download_test_file
 
@@ -81,7 +81,7 @@ def template_path(tempdir, request):
             np.save(tempdir / 'spikes.times.npy', st / 25000.)  # sample rate
             _remove(tempdir / 'spike_times.npy')
         # Buggy TSV file should not cause a crash.
-        _write_text(tempdir / 'error.tsv', '')
+        write_text(tempdir / 'error.tsv', '')
         # Remove some non-necessary files.
         _remove(tempdir / 'template_features.npy')
         _remove(tempdir / 'pc_features.npy')
@@ -98,7 +98,7 @@ def template_path(tempdir, request):
 
 @fixture
 def template_model(template_path):
-    params = _read_python(template_path)
+    params = read_python(template_path)
     params['dat_path'] = template_path.parent / params['dat_path']
     params['dir_path'] = template_path.parent
     model = TemplateModel(**params)

--- a/phylib/io/tests/conftest.py
+++ b/phylib/io/tests/conftest.py
@@ -88,7 +88,7 @@ def template_path(tempdir, request):
         _remove(tempdir / 'sim_binary.dat')
 
     # Spike attributes.
-    write_array(tempdir / 'spike_fail.npy', np.random.rand(10))  # wrong number of spikes
+    write_array(tempdir / 'spike_fail.npy', np.full(10, np.nan))  # wrong number of spikes
     write_array(tempdir / 'spike_works.npy', np.random.rand(314))
     write_array(tempdir / 'spike_randn.npy', np.random.randn(314, 2))
 

--- a/phylib/io/tests/conftest.py
+++ b/phylib/io/tests/conftest.py
@@ -34,6 +34,7 @@ _FILES = ['template/params.py',
 
           'template/channel_map.npy',
           'template/channel_positions.npy',
+          'template/channel_shanks.npy',
 
           'template/similar_templates.npy',
           'template/whitening_mat.npy',
@@ -85,6 +86,7 @@ def template_path_full(tempdir, request):
         # Remove some non-necessary files.
         _remove(tempdir / 'template_features.npy')
         _remove(tempdir / 'pc_features.npy')
+        _remove(tempdir / 'channel_shanks.npy')
         _remove(tempdir / 'sim_binary.dat')
 
     # Spike attributes.

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -15,7 +15,7 @@ from pytest import fixture, raises
 import numpy as np
 import numpy.random as nr
 
-from phylib.utils._misc import _write_tsv
+from phylib.utils._misc import _write_tsv_simple
 from ..alf import _FILE_RENAMES, _load, EphysAlfCreator
 from ..model import TemplateModel
 
@@ -40,7 +40,7 @@ class Dataset(object):
         np.save(p / 'templates.npy', np.random.normal(size=(self.nt, 50, self.nc)))
         np.save(p / 'similar_templates.npy', np.tile(np.arange(self.nt), (self.nt, 1)))
         np.save(p / 'channel_map.npy', np.c_[np.arange(self.nc)])
-        _write_tsv(p / 'cluster_group.tsv', 'group', {2: 'good', 3: 'mua', 5: 'noise'})
+        _write_tsv_simple(p / 'cluster_group.tsv', 'group', {2: 'good', 3: 'mua', 5: 'noise'})
 
         # Raw data
         self.dat_path = p / 'rawdata.npy'

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -82,7 +82,7 @@ def test_creator(dataset):
     out_path = path / 'alf'
 
     model = TemplateModel(
-        dataset.dat_path, sample_rate=2000, n_channels_dat=dataset.ncd)
+        dir_path=path, dat_path=dataset.dat_path, sample_rate=2000, n_channels_dat=dataset.ncd)
 
     c = EphysAlfCreator(model)
     with raises(IOError):

--- a/phylib/io/tests/test_array.py
+++ b/phylib/io/tests/test_array.py
@@ -11,34 +11,12 @@ from pathlib import Path
 import numpy as np
 from pytest import raises
 
-from ..array import (_unique,
-                     _normalize,
-                     _index_of,
-                     _in_polygon,
-                     _spikes_in_clusters,
-                     _spikes_per_cluster,
-                     _flatten_per_cluster,
-                     get_closest_clusters,
-                     _get_data_lim,
-                     _flatten,
-                     _start_stop,
-                     select_spikes,
-                     Selector,
-                     chunk_bounds,
-                     regular_subset,
-                     excerpts,
-                     data_chunk,
-                     grouped_mean,
-                     get_excerpts,
-                     _concatenate_virtual_arrays,
-                     _range_from_slice,
-                     _pad,
-                     _get_padded,
-                     read_array,
-                     write_array,
-                     Accumulator,
-                     _accumulate,
-                     )
+from ..array import (
+    _unique, _normalize, _index_of, _in_polygon, _spikes_in_clusters, _spikes_per_cluster,
+    _flatten_per_cluster, get_closest_clusters, _get_data_lim, _flatten, _start_stop,
+    select_spikes, Selector, chunk_bounds, regular_subset, excerpts, data_chunk, grouped_mean,
+    get_excerpts, _concatenate_virtual_arrays, _range_from_slice, _pad, _get_padded,
+    read_array, write_array)
 from phylib.utils._types import _as_array
 from phylib.utils.testing import _assert_equal as ae
 from ..mock import artificial_spike_clusters
@@ -447,27 +425,3 @@ def test_select_spikes_random():
                       )
     assert len(s) == 2
     assert np.all(np.in1d(s, [2, 3, 4]))
-
-
-#------------------------------------------------------------------------------
-# Test accumulator
-#------------------------------------------------------------------------------
-
-def test_accumulator_1():
-    acc = Accumulator()
-    acc.add('a', [0])
-    acc.add('a', [1])
-    assert acc.get('a') == [0, 1]
-
-
-def test_accumulator_2():
-    acc = _accumulate([{'a': np.arange(3), 'b': np.arange(3) * 10,
-                        'c': 0},
-                       {'a': np.arange(3, 5), 'b': np.arange(3, 5) * 10,
-                        'c': 1},
-                       ])
-    ae(acc['a'], np.arange(5))
-    ae(acc['b'], np.arange(5) * 10)
-    # NOTE: in case of scalars, we take the first one and discard the others.
-    # We don't concatenate them.
-    assert acc['c'] == 0

--- a/phylib/io/tests/test_model.py
+++ b/phylib/io/tests/test_model.py
@@ -88,7 +88,7 @@ def test_model_metadata_1(template_model):
     assert m.get_metadata('quality').get(6, None) is None
     m.save_metadata('quality', {6: 3})
     m.metadata = m._load_metadata()
-    assert m.get_metadata('quality').get(6, None) == '3'
+    assert m.get_metadata('quality').get(6, None) == 3
 
 
 def test_model_metadata_2(template_model):
@@ -98,7 +98,7 @@ def test_model_metadata_2(template_model):
     m.save_metadata('quality', {0: None, 1: 1})
     m.metadata = m._load_metadata()
     assert m.get_metadata('quality').get(0, None) is None
-    assert m.get_metadata('quality').get(1, None) == '1'
+    assert m.get_metadata('quality').get(1, None) == 1
 
 
 def test_model_spike_attributes(template_model):

--- a/phylib/io/tests/test_model.py
+++ b/phylib/io/tests/test_model.py
@@ -57,7 +57,7 @@ def test_model_2(template_model):
     m = template_model
     tmp = m.get_template(3)
     channel_ids = tmp.channel_ids
-    spike_ids = m.spikes_in_template(3)
+    spike_ids = m.get_cluster_spikes(3)
 
     w = m.get_waveforms(spike_ids, channel_ids)
     assert w is None or w.shape == (len(spike_ids), tmp.template.shape[0], len(channel_ids))
@@ -67,6 +67,42 @@ def test_model_2(template_model):
 
     tf = m.get_template_features(spike_ids)
     assert tf is None or tf.shape == (len(spike_ids), m.n_templates)
+
+
+def test_model_3(template_model):
+    m = template_model
+
+    spike_ids = m.get_template_spikes(3)
+    n_spikes = len(spike_ids)
+
+    channel_ids = m.get_template_channels(3)
+    n_channels = len(channel_ids)
+
+    waveforms = m.get_template_spike_waveforms(3)
+    if waveforms is not None:
+        assert waveforms.ndim == 3
+        assert waveforms.shape[0] == n_spikes
+        assert waveforms.shape[2] == n_channels
+
+    tw = m.get_template_waveforms(3)
+    assert tw.ndim == 2
+    assert tw.shape[1] == n_channels
+
+
+def test_model_4(template_model):
+    m = template_model
+
+    spike_ids = m.get_cluster_spikes(3)
+    n_spikes = len(spike_ids)
+
+    channel_ids = m.get_cluster_channels(3)
+    n_channels = len(channel_ids)
+
+    waveforms = m.get_cluster_spike_waveforms(3)
+    if waveforms is not None:
+        assert waveforms.ndim == 3
+        assert waveforms.shape[0] == n_spikes
+        assert waveforms.shape[2] == n_channels
 
 
 def test_model_save(template_model):

--- a/phylib/io/tests/test_model.py
+++ b/phylib/io/tests/test_model.py
@@ -111,30 +111,28 @@ def test_model_save(template_model_full):
     m.save_spike_clusters(m.spike_clusters)
     m.save_mean_waveforms({1: Bunch(
         channel_ids=np.arange(m.n_channels),
-        data=np.zeros((1, m.n_samples_templates, m.n_channels)))})
+        data=np.zeros((1, m.n_samples_waveforms, m.n_channels)))})
 
 
 def test_model_metadata_1(template_model_full):
     m = template_model_full
-    assert m.metadata_fields
 
-    assert m.get_metadata('group').get(4, None) == 'good'
-    assert m.get_metadata('unknown').get(4, None) is None
+    assert m.metadata.get('group', {}).get(4, None) == 'good'
+    assert m.metadata.get('unknown', {}).get(4, None) is None
 
-    assert m.get_metadata('quality').get(6, None) is None
+    assert m.metadata.get('quality', {}).get(6, None) is None
     m.save_metadata('quality', {6: 3})
     m.metadata = m._load_metadata()
-    assert m.get_metadata('quality').get(6, None) == 3
+    assert m.metadata.get('quality', {}).get(6, None) == 3
 
 
 def test_model_metadata_2(template_model):
     m = template_model
-    assert m.metadata_fields
 
     m.save_metadata('quality', {0: None, 1: 1})
     m.metadata = m._load_metadata()
-    assert m.get_metadata('quality').get(0, None) is None
-    assert m.get_metadata('quality').get(1, None) == 1
+    assert m.metadata.get('quality', {}).get(0, None) is None
+    assert m.metadata.get('quality', {}).get(1, None) == 1
 
 
 def test_model_spike_attributes(template_model_full):

--- a/phylib/io/tests/test_model.py
+++ b/phylib/io/tests/test_model.py
@@ -45,16 +45,16 @@ def test_from_sparse():
         _test([19, 19], [[0, 0], [4, 4]])
 
 
-def test_model_1(template_model):
+def test_model_1(template_model_full):
     with captured_output() as (stdout, stderr):
-        template_model.describe()
+        template_model_full.describe()
     out = stdout.getvalue()
     assert 'sim_binary.dat' in out
     assert '64' in out
 
 
-def test_model_2(template_model):
-    m = template_model
+def test_model_2(template_model_full):
+    m = template_model_full
     tmp = m.get_template(3)
     channel_ids = tmp.channel_ids
     spike_ids = m.get_cluster_spikes(3)
@@ -69,8 +69,8 @@ def test_model_2(template_model):
     assert tf is None or tf.shape == (len(spike_ids), m.n_templates)
 
 
-def test_model_3(template_model):
-    m = template_model
+def test_model_3(template_model_full):
+    m = template_model_full
 
     spike_ids = m.get_template_spikes(3)
     n_spikes = len(spike_ids)
@@ -89,8 +89,8 @@ def test_model_3(template_model):
     assert tw.shape[1] == n_channels
 
 
-def test_model_4(template_model):
-    m = template_model
+def test_model_4(template_model_full):
+    m = template_model_full
 
     spike_ids = m.get_cluster_spikes(3)
     n_spikes = len(spike_ids)
@@ -105,8 +105,8 @@ def test_model_4(template_model):
         assert waveforms.shape[2] == n_channels
 
 
-def test_model_save(template_model):
-    m = template_model
+def test_model_save(template_model_full):
+    m = template_model_full
     m.save_metadata('test', {1: 1})
     m.save_spike_clusters(m.spike_clusters)
     m.save_mean_waveforms({1: Bunch(
@@ -114,8 +114,8 @@ def test_model_save(template_model):
         data=np.zeros((1, m.n_samples_templates, m.n_channels)))})
 
 
-def test_model_metadata_1(template_model):
-    m = template_model
+def test_model_metadata_1(template_model_full):
+    m = template_model_full
     assert m.metadata_fields
 
     assert m.get_metadata('group').get(4, None) == 'good'
@@ -137,7 +137,8 @@ def test_model_metadata_2(template_model):
     assert m.get_metadata('quality').get(1, None) == 1
 
 
-def test_model_spike_attributes(template_model):
-    assert set(template_model.spike_attributes.keys()) == set(('randn', 'works'))
-    assert template_model.spike_attributes.works.shape == (template_model.n_spikes,)
-    assert template_model.spike_attributes.randn.shape == (template_model.n_spikes, 2)
+def test_model_spike_attributes(template_model_full):
+    model = template_model_full
+    assert set(model.spike_attributes.keys()) == set(('randn', 'works'))
+    assert model.spike_attributes.works.shape == (model.n_spikes,)
+    assert model.spike_attributes.randn.shape == (model.n_spikes, 2)

--- a/phylib/stats/ccg.py
+++ b/phylib/stats/ccg.py
@@ -54,10 +54,7 @@ def _symmetrize_correlograms(correlograms):
     return np.dstack((sym, correlograms))
 
 
-def firing_rate(spike_clusters,
-                cluster_ids=None,
-                bin_size=None,
-                duration=None):
+def firing_rate(spike_clusters, cluster_ids=None, bin_size=None, duration=None):
     """Compute the average number of spikes per cluster per bin."""
 
     # Take the cluster order into account.
@@ -75,14 +72,9 @@ def firing_rate(spike_clusters,
     return bc * np.c_[bc] * (bin_size / duration)
 
 
-def correlograms(spike_times,
-                 spike_clusters,
-                 cluster_ids=None,
-                 sample_rate=1.,
-                 bin_size=None,
-                 window_size=None,
-                 symmetrize=True,
-                 ):
+def correlograms(
+        spike_times, spike_clusters, cluster_ids=None, sample_rate=1.,
+        bin_size=None, window_size=None, symmetrize=True):
     """Compute all pairwise cross-correlograms among the clusters appearing
     in `spike_clusters`.
 
@@ -100,13 +92,16 @@ def correlograms(spike_times,
         Size of the bin, in seconds.
     window_size : float
         Size of the window, in seconds.
+    sample_rate : float
+        Sampling rate.
+    symmetrize : boolean (True)
+        Whether the output matrix should be symmetrized or not.
 
     Returns
     -------
 
     correlograms : array
-        A `(n_clusters, n_clusters, winsize_samples)` array with all pairwise
-        CCGs.
+        A `(n_clusters, n_clusters, winsize_samples)` array with all pairwise CCGs.
 
     """
     assert sample_rate > 0.

--- a/phylib/stats/ccg.py
+++ b/phylib/stats/ccg.py
@@ -66,7 +66,6 @@ def firing_rate(spike_clusters, cluster_ids=None, bin_size=None, duration=None):
     # Like spike_clusters, but with 0..n_clusters-1 indices.
     spike_clusters_i = _index_of(spike_clusters, cluster_ids)
 
-    assert duration > 0
     assert bin_size > 0
     bc = np.bincount(spike_clusters_i)
     # Handle the case where the last cluster(s) are empty.
@@ -74,7 +73,7 @@ def firing_rate(spike_clusters, cluster_ids=None, bin_size=None, duration=None):
         n = len(cluster_ids) - len(bc)
         bc = np.concatenate((bc, np.zeros(n, dtype=bc.dtype)))
     assert bc.shape == (len(cluster_ids),)
-    return bc * np.c_[bc] * (bin_size / duration)
+    return bc * np.c_[bc] * (bin_size / (duration or 1.))
 
 
 def correlograms(

--- a/phylib/stats/ccg.py
+++ b/phylib/stats/ccg.py
@@ -59,16 +59,21 @@ def firing_rate(spike_clusters, cluster_ids=None, bin_size=None, duration=None):
 
     # Take the cluster order into account.
     if cluster_ids is None:
-        clusters = _unique(spike_clusters)
+        cluster_ids = _unique(spike_clusters)
     else:
-        clusters = _as_array(cluster_ids)
+        cluster_ids = _as_array(cluster_ids)
 
     # Like spike_clusters, but with 0..n_clusters-1 indices.
-    spike_clusters_i = _index_of(spike_clusters, clusters)
+    spike_clusters_i = _index_of(spike_clusters, cluster_ids)
 
     assert duration > 0
     assert bin_size > 0
     bc = np.bincount(spike_clusters_i)
+    # Handle the case where the last cluster(s) are empty.
+    if len(bc) < len(cluster_ids):
+        n = len(cluster_ids) - len(bc)
+        bc = np.concatenate((bc, np.zeros(n, dtype=bc.dtype)))
+    assert bc.shape == (len(cluster_ids),)
     return bc * np.c_[bc] * (bin_size / duration)
 
 

--- a/phylib/stats/ccg.py
+++ b/phylib/stats/ccg.py
@@ -172,10 +172,8 @@ def correlograms(
 
         # Find the indices in the raveled correlograms array that need
         # to be incremented, taking into account the spike clusters.
-        indices = np.ravel_multi_index((spike_clusters_i[:-shift][m],
-                                        spike_clusters_i[+shift:][m],
-                                        d),
-                                       correlograms.shape)
+        indices = np.ravel_multi_index(
+            (spike_clusters_i[:-shift][m], spike_clusters_i[+shift:][m], d), correlograms.shape)
 
         # Increment the matching spikes in the correlograms array.
         _increment(correlograms.ravel(), indices)
@@ -183,9 +181,7 @@ def correlograms(
         shift += 1
 
     # Remove ACG peaks.
-    correlograms[np.arange(n_clusters),
-                 np.arange(n_clusters),
-                 0] = 0
+    correlograms[np.arange(n_clusters), np.arange(n_clusters), 0] = 0
 
     if symmetrize:
         return _symmetrize_correlograms(correlograms)

--- a/phylib/stats/ccg.py
+++ b/phylib/stats/ccg.py
@@ -184,9 +184,6 @@ def correlograms(
 
         shift += 1
 
-    # Remove ACG peaks.
-    correlograms[np.arange(n_clusters), np.arange(n_clusters), 0] = 0
-
     if symmetrize:
         return _symmetrize_correlograms(correlograms)
     else:

--- a/phylib/stats/clusters.py
+++ b/phylib/stats/clusters.py
@@ -14,20 +14,23 @@ import numpy as np
 #------------------------------------------------------------------------------
 
 def mean(x):
+    """Return the mean of an array across the first dimension."""
     return x.mean(axis=0)
 
 
 def get_unmasked_channels(mean_masks, min_mask=.25):
+    """Return the unmasked channels (mean masks above a given threshold)."""
     return np.nonzero(mean_masks > min_mask)[0]
 
 
 def get_mean_probe_position(mean_masks, site_positions):
-    return (np.sum(site_positions * mean_masks[:, np.newaxis], axis=0) /
-            max(1, np.sum(mean_masks)))
+    """Return the mean position of clusters on the probe, depending on the masks."""
+    m = max(1, np.sum(mean_masks))
+    return np.sum(site_positions * mean_masks[:, np.newaxis], axis=0) / m
 
 
 def get_sorted_main_channels(mean_masks, unmasked_channels):
-    # Weighted mean of the channels, weighted by the mean masks.
+    """Weighted mean of the channels, weighted by the mean masks."""
     main_channels = np.argsort(mean_masks)[::-1]
     main_channels = np.array([c for c in main_channels
                               if c in unmasked_channels])
@@ -55,12 +58,8 @@ def get_waveform_amplitude(mean_masks, mean_waveforms):
     return M - m
 
 
-def get_mean_masked_features_distance(mean_features_0,
-                                      mean_features_1,
-                                      mean_masks_0,
-                                      mean_masks_1,
-                                      n_features_per_channel=None,
-                                      ):
+def get_mean_masked_features_distance(
+        mean_features_0, mean_features_1, mean_masks_0, mean_masks_1, n_features_per_channel=None):
     """Compute the distance between the mean masked features."""
 
     assert n_features_per_channel > 0

--- a/phylib/stats/tests/test_ccg.py
+++ b/phylib/stats/tests/test_ccg.py
@@ -194,7 +194,4 @@ def test_symmetrize_correlograms():
     for i in range(3):
         ae(sym[i, i, :], sym[i, i, ::-1])
 
-    # Check that ACG peak is 0.
-    assert np.all(sym[np.arange(3), np.arange(3), 25] == 0)
-
     ae(sym[0, 1, :], sym[1, 0, ::-1])

--- a/phylib/stats/tests/test_ccg.py
+++ b/phylib/stats/tests/test_ccg.py
@@ -64,6 +64,17 @@ def test_firing_rate_0():
 
 
 def test_firing_rate_1():
+    spike_clusters = [0, 1, 0, 1]
+    bin_size = 1
+
+    fr = firing_rate(spike_clusters, cluster_ids=[0, 1, 2], bin_size=bin_size, duration=20)
+    print(fr)
+    ae(fr[:2, :2], .2 * np.ones((2, 2)))
+    assert np.all(fr[2, :] == fr[:, 2])
+    assert np.all(fr[2, :] == 0)
+
+
+def test_firing_rate_2():
     spike_clusters = np.tile(np.arange(10), 100)
     fr = firing_rate(spike_clusters, cluster_ids=np.arange(10), bin_size=.1, duration=1.)
     ae(fr, np.ones((10, 10)) * 1000)
@@ -112,9 +123,9 @@ def test_ccg_2():
     spike_samples, spike_clusters = _random_data(max_cluster)
     bin_size, winsize_bins = _ccg_params()
 
-    c = correlograms(spike_samples, spike_clusters,
-                     bin_size=bin_size, window_size=winsize_bins,
-                     sample_rate=20000, symmetrize=False)
+    c = correlograms(
+        spike_samples, spike_clusters, bin_size=bin_size, window_size=winsize_bins,
+        sample_rate=20000, symmetrize=False)
 
     assert c.shape == (max_cluster, max_cluster, 26)
 

--- a/phylib/traces/waveform.py
+++ b/phylib/traces/waveform.py
@@ -271,10 +271,7 @@ class WaveformLoader(object):
     def get(self, spike_ids, channels=None):
         """Load the waveforms of the specified spikes."""
         if isinstance(spike_ids, slice):
-            spike_ids = _range_from_slice(spike_ids,
-                                          start=0,
-                                          stop=self.n_spikes,
-                                          )
+            spike_ids = _range_from_slice(spike_ids, start=0, stop=self.n_spikes)
         if not hasattr(spike_ids, '__len__'):
             spike_ids = [spike_ids]
         if channels is None:

--- a/phylib/utils/__init__.py
+++ b/phylib/utils/__init__.py
@@ -3,7 +3,9 @@
 
 """Utilities."""
 
-from ._misc import load_json, save_json, load_pickle, save_pickle, _fullname
+from ._misc import (
+    load_json, save_json, load_pickle, save_pickle, _fullname, read_python,
+    read_text, write_text, read_tsv, write_tsv)
 from ._types import (
     _is_array_like, _as_array, _as_tuple, _as_list, _as_scalar, _as_scalars,
     Bunch, _is_list, _bunchify)

--- a/phylib/utils/__init__.py
+++ b/phylib/utils/__init__.py
@@ -3,11 +3,8 @@
 
 """Utilities."""
 
-from ._misc import (_load_json, _save_json,
-                    _load_pickle, _save_pickle,
-                    _fullname,
-                    )
-from ._types import (_is_array_like, _as_array, _as_tuple, _as_list,
-                     _as_scalar, _as_scalars,
-                     Bunch, _is_list, _bunchify)
-from .event import ProgressReporter, emit, connect, unconnect, silent, reset
+from ._misc import _load_json, _save_json, _load_pickle, _save_pickle, _fullname
+from ._types import (
+    _is_array_like, _as_array, _as_tuple, _as_list, _as_scalar, _as_scalars,
+    Bunch, _is_list, _bunchify)
+from .event import ProgressReporter, emit, connect, unconnect, silent, reset, set_silent

--- a/phylib/utils/__init__.py
+++ b/phylib/utils/__init__.py
@@ -3,7 +3,7 @@
 
 """Utilities."""
 
-from ._misc import _load_json, _save_json, _load_pickle, _save_pickle, _fullname
+from ._misc import load_json, save_json, load_pickle, save_pickle, _fullname
 from ._types import (
     _is_array_like, _as_array, _as_tuple, _as_list, _as_scalar, _as_scalars,
     Bunch, _is_list, _bunchify)

--- a/phylib/utils/_misc.py
+++ b/phylib/utils/_misc.py
@@ -95,10 +95,10 @@ def _stringify_keys(d):
     return out
 
 
-def _pretty_floats(obj, n=4):
+def _pretty_floats(obj, n=2):
     """Display floating point numbers properly."""
     if isinstance(obj, (float, np.float64, np.float32)):
-        return ('%.' + str(n) + 'g') % obj
+        return ('%.' + str(n) + 'f') % obj
     elif isinstance(obj, dict):
         return dict((k, _pretty_floats(v)) for k, v in obj.items())
     elif isinstance(obj, (list, tuple)):

--- a/phylib/utils/_misc.py
+++ b/phylib/utils/_misc.py
@@ -119,11 +119,17 @@ def load_json(path):
 
 
 def save_json(path, data):
-    """Save a dictionary to a JSON file."""
+    """Save a dictionary to a JSON file.
+
+    Support NumPy arrays and QByteArray objects. NumPy arrays are saved as base64-encoded strings,
+    except for 1D arrays with less than 10 elements, which are saved as a list for human
+    readability.
+
+    """
     assert isinstance(data, dict)
     data = _stringify_keys(data)
     path = Path(path)
-    _ensure_dir_exists(path.parent)
+    ensure_dir_exists(path.parent)
     with path.open('w') as f:
         json.dump(data, f, cls=_CustomEncoder, indent=2, sort_keys=True)
 
@@ -145,7 +151,20 @@ def save_pickle(path, data):
 
 
 def read_python(path):
-    """Read a Python file."""
+    """Read a Python file.
+
+    Parameters
+    ----------
+
+    path : str or Path
+
+    Returns
+    -------
+
+    metadata : dict
+        A dictionary containing all variables defined in the Python file (with `exec()`).
+
+    """
     path = Path(path)
     if not path.exists():  # pragma: no cover
         raise IOError("Path %s does not exist.", path)
@@ -166,7 +185,7 @@ def write_text(path, contents):
     """Write a text file."""
     contents = dedent(contents)
     path = Path(path)
-    _ensure_dir_exists(path.parent)
+    ensure_dir_exists(path.parent)
     path.write_text(contents)
 
 
@@ -185,7 +204,10 @@ def _try_make_number(value):
 def read_tsv(path):
     """Read a CSV/TSV file.
 
-    Return a list of dictionaries.
+    Returns
+    -------
+
+    data : list of dicts
 
     """
     path = Path(path)
@@ -209,11 +231,20 @@ def read_tsv(path):
 def write_tsv(path, data, first_field=None, exclude_fields=(), n_significant_figures=4):
     """Write a CSV/TSV file.
 
-    data is a list of dictionaries.
+    Parameters
+    ----------
+
+    data : list of dicts
+    first_field : str
+        The name of the field that should come first in the file.
+    exclude_fields : list-like
+        Fields present in the data that should not be saved in the file.
+    n_significant_figures : int
+        Number of significant figures used for floating-point numbers in the file.
 
     """
     path = Path(path)
-    _ensure_dir_exists(path.parent)
+    ensure_dir_exists(path.parent)
     delimiter = '\t' if path.suffix == '.tsv' else ','
     with path.open('w', newline='') as f:
         if not data:
@@ -274,7 +305,7 @@ def _write_tsv_simple(path, field_name, data):
 
     """
     path = Path(path)
-    _ensure_dir_exists(path.parent)
+    ensure_dir_exists(path.parent)
     delimiter = '\t' if path.suffix == '.tsv' else ','
     with path.open('w', newline='') as f:
         writer = csv.writer(f, delimiter=delimiter)
@@ -317,12 +348,12 @@ def _git_version():
 
 
 def phy_config_dir():
-    """Return the absolute path to the phy user directory."""
+    """Return the absolute path to the phy user directory. By default, `~/.phy/`."""
     return Path.home() / '.phy'
 
 
-def _ensure_dir_exists(path):
-    """Ensure a directory exists."""
+def ensure_dir_exists(path):
+    """Ensure a directory exists, and create it otherwise."""
     path = Path(path)
     if path.exists():
         assert path.is_dir()

--- a/phylib/utils/_misc.py
+++ b/phylib/utils/_misc.py
@@ -95,10 +95,10 @@ def _stringify_keys(d):
     return out
 
 
-def _pretty_floats(obj):
+def _pretty_floats(obj, n=4):
     """Display floating point numbers properly."""
     if isinstance(obj, (float, np.float64, np.float32)):
-        return '%.4g' % obj
+        return ('%.' + str(n) + 'g') % obj
     elif isinstance(obj, dict):
         return dict((k, _pretty_floats(v)) for k, v in obj.items())
     elif isinstance(obj, (list, tuple)):
@@ -206,7 +206,7 @@ def read_tsv(path):
     return data
 
 
-def write_tsv(path, data, first_field=None, exclude_fields=()):
+def write_tsv(path, data, first_field=None, exclude_fields=(), n_significant_figures=4):
     """Write a CSV/TSV file.
 
     data is a list of dictionaries.
@@ -236,7 +236,8 @@ def write_tsv(path, data, first_field=None, exclude_fields=()):
         writer.writerow(fields)
         # Write all rows.
         writer.writerows(
-            [[_pretty_floats(row.get(field, None)) for field in fields] for row in data])
+            [[_pretty_floats(row.get(field, None), n_significant_figures)
+             for field in fields] for row in data])
     logger.debug("Wrote %s.", path)
 
 

--- a/phylib/utils/_misc.py
+++ b/phylib/utils/_misc.py
@@ -184,7 +184,7 @@ def _read_tsv(path):
             cluster_id, value = row
             cluster_id = int(cluster_id)
             data[cluster_id] = value
-    logger.info("Read %s.", path)
+    logger.debug("Read %s.", path)
     return field_name, data
 
 
@@ -201,7 +201,7 @@ def _write_tsv(path, field_name, data):
         writer = csv.writer(f, delimiter=delimiter)
         writer.writerow(['cluster_id', field_name])
         writer.writerows([(cluster_id, data[cluster_id]) for cluster_id in sorted(data)])
-    logger.info("Wrote %s.", path)
+    logger.debug("Wrote %s.", path)
 
 
 def _git_version():

--- a/phylib/utils/_types.py
+++ b/phylib/utils/_types.py
@@ -20,12 +20,13 @@ _ACCEPTED_ARRAY_DTYPES = (
 
 
 class Bunch(dict):
-    """A dict with additional dot syntax."""
+    """A subclass of dictionary with an additional dot syntax."""
     def __init__(self, *args, **kwargs):
         super(Bunch, self).__init__(*args, **kwargs)
         self.__dict__ = self
 
     def copy(self):
+        """Return a new Bunch instance which is a copy of the current Bunch instance."""
         return Bunch(super(Bunch, self).copy())
 
 

--- a/phylib/utils/_types.py
+++ b/phylib/utils/_types.py
@@ -14,10 +14,9 @@ import numpy as np
 # Various Python utility functions
 #------------------------------------------------------------------------------
 
-_ACCEPTED_ARRAY_DTYPES = (np.float, np.float32, np.float64,
-                          np.int, np.int8, np.int16, np.uint8, np.uint16,
-                          np.int32, np.int64, np.uint32, np.uint64,
-                          np.bool)
+_ACCEPTED_ARRAY_DTYPES = (
+    np.float, np.float32, np.float64, np.int, np.int8, np.int16, np.uint8, np.uint16,
+    np.int32, np.int64, np.uint32, np.uint64, np.bool)
 
 
 class Bunch(dict):
@@ -41,10 +40,12 @@ def _bunchify(b):
 
 
 def _is_list(obj):
+    """Return whether an object is a list."""
     return isinstance(obj, list)
 
 
 def _as_scalar(obj):
+    """Return whether an object is a scalar number (integer or floating point number)."""
     if isinstance(obj, np.generic):
         return obj.item()
     assert isinstance(obj, (int, float))
@@ -52,14 +53,17 @@ def _as_scalar(obj):
 
 
 def _as_scalars(arr):
+    """Make sure a list only contains scalar numbers."""
     return [_as_scalar(x) for x in arr]
 
 
 def _is_integer(x):
+    """Return whether an object is an integer."""
     return isinstance(x, (int, np.generic))
 
 
 def _is_float(x):
+    """Return whether an object is a floating point number."""
     return isinstance(x, (float, np.float32, np.float64))
 
 
@@ -78,6 +82,7 @@ def _as_list(obj):
 
 
 def _is_array_like(arr):
+    """Return whether an object is an array or a list."""
     return isinstance(arr, (list, np.ndarray))
 
 

--- a/phylib/utils/color.py
+++ b/phylib/utils/color.py
@@ -194,7 +194,7 @@ class ClusterColorSelector(object):
     _logarithmic = False
 
     def __init__(
-            self, cluster_meta=None, cluster_metrics=None, field=None,
+            self, cluster_meta=None, cluster_metrics=None, color_field=None,
             colormap=None, categorical=None, logarithmic=None, cluster_ids=None):
         self.cluster_ids = None
         self.cluster_meta = cluster_meta or None
@@ -205,7 +205,8 @@ class ClusterColorSelector(object):
         self.cluster_ids = cluster_ids
         # self._colormap = colormap if colormap is not None else self._colormap
         self.set_color_mapping(
-            field=field, colormap=colormap, categorical=categorical, logarithmic=logarithmic)
+            color_field=color_field, colormap=colormap,
+            categorical=categorical, logarithmic=logarithmic)
 
     @property
     def state(self):
@@ -224,15 +225,16 @@ class ClusterColorSelector(object):
 
     def set_state(self, state):
         self.set_color_mapping(
-            field=state.color_field, colormap=state.colormap,
+            color_field=state.color_field, colormap=state.colormap,
             categorical=state.categorical, logarithmic=state.logarithmic)
 
-    def set_color_mapping(self, field=None, colormap=None, categorical=None, logarithmic=None):
+    def set_color_mapping(
+            self, color_field=None, colormap=None, categorical=None, logarithmic=None):
         """Set the field used to choose the cluster colors, and the associated colormap."""
         if isinstance(colormap, str):
             colormap = colormaps[colormap]
         self._colormap = colormap if colormap is not None else self._colormap
-        self._color_field = field or self._color_field
+        self._color_field = color_field or self._color_field
         self._categorical = categorical if categorical is not None else self._categorical
         self._logarithmic = logarithmic if logarithmic is not None else self._logarithmic
         # Recompute the value range.

--- a/phylib/utils/color.py
+++ b/phylib/utils/color.py
@@ -192,9 +192,13 @@ def add_alpha(c, alpha=1.):
 
     """
     if isinstance(c, (tuple,)):
+        if len(c) == 4:
+            c = c[:3]
         return c + (alpha,)
     elif isinstance(c, np.ndarray):
         assert c.ndim == 2
+        if c.shape[1] == 4:
+            c = c[:, :3]
         assert c.shape[1] == 3
         return np.c_[c, alpha * np.ones((c.shape[0], 1))]
     raise ValueError("Unknown value given in add_alpha().")

--- a/phylib/utils/color.py
+++ b/phylib/utils/color.py
@@ -150,7 +150,7 @@ def _make_cluster_group_colormap():
     ])
 
 
-# Built-in colormaps.
+"""Built-in colormaps."""
 colormaps = Bunch(
     default=_make_default_colormap(),
     cluster_group=_make_cluster_group_colormap(),
@@ -162,7 +162,7 @@ colormaps = Bunch(
 
 
 def selected_cluster_color(i, alpha=1.):
-    """Return the color of the i-th selected cluster."""
+    """Return the color, as a 4-tuple, of the i-th selected cluster."""
     return add_alpha(tuple(colormaps.default[i % len(colormaps.default)]), alpha=alpha)
 
 
@@ -182,7 +182,15 @@ def _add_selected_clusters_colors(selected_clusters, cluster_ids, cluster_colors
 #------------------------------------------------------------------------------
 
 def add_alpha(c, alpha=1.):
-    """Add an alpha channel to an RGB color."""
+    """Add an alpha channel to an RGB color.
+
+    Parameters
+    ----------
+
+    c : array-like (2D, shape[1] == 3) or 3-tuple
+    alpha : float
+
+    """
     if isinstance(c, (tuple,)):
         return c + (alpha,)
     elif isinstance(c, np.ndarray):
@@ -226,7 +234,8 @@ class ClusterColorSelector(object):
 
     @property
     def state(self):
-        """Colormap state."""
+        """Colormap state. This is a Bunch with the following keys: color_field, colormap,
+        categorical, logarithmic."""
         colormap_name = None
         # Find the colormap name from the colormap array.
         for cname, arr in colormaps.items():
@@ -248,7 +257,22 @@ class ClusterColorSelector(object):
 
     def set_color_mapping(
             self, color_field=None, colormap=None, categorical=None, logarithmic=None):
-        """Set the field used to choose the cluster colors, and the associated colormap."""
+        """Set the field used to choose the cluster colors, and the associated colormap.
+
+        Parameters
+        ----------
+
+        color_field : str
+            Name of the cluster metrics or label to use for the color.
+        colormap : array-like
+            A `(N, 3)` array with the colormaps colors
+        categorical : boolean
+            Whether the colormap is categorical (one value = one color) or continuous (values
+            are continuously mapped from their initial interval to the colors).
+        logarithmic : boolean
+            Whether to use a logarithmic transform for the mapping.
+
+        """
         if isinstance(colormap, str):
             colormap = colormaps[colormap]
         self._colormap = colormap if colormap is not None else self._colormap
@@ -266,7 +290,19 @@ class ClusterColorSelector(object):
             self.vmin, self.vmax = values.min(), values.max()
 
     def map(self, values):
-        """Convert values to colors using the selected colormap."""
+        """Convert values to colors using the selected colormap.
+
+        Parameters
+        ----------
+
+        values : array-like (1D)
+
+        Returns
+        -------
+
+        colors : array-like (2D, shape[1] == 3)
+
+        """
         if self._logarithmic:
             assert np.all(values > 0)
             values = np.log(values)
@@ -293,7 +329,7 @@ class ClusterColorSelector(object):
         return 0
 
     def get(self, cluster_id, alpha=None):
-        """Return the color of a given cluster."""
+        """Return the RGBA color of a single cluster."""
         assert self.cluster_ids is not None
         assert self._colormap is not None
         val = self._get_cluster_value(cluster_id)
@@ -307,7 +343,7 @@ class ClusterColorSelector(object):
         return np.array(values)
 
     def get_colors(self, cluster_ids, alpha=1.):
-        """Return the colors of some clusters."""
+        """Return the RGBA colors of some clusters."""
         values = self.get_values(cluster_ids)
         assert values is not None
         assert len(values) == len(cluster_ids)

--- a/phylib/utils/event.py
+++ b/phylib/utils/event.py
@@ -44,7 +44,10 @@ class EventEmitter(object):
 
     def __init__(self):
         self.reset()
-        self._is_silent = False
+        self.is_silent = False
+
+    def set_silent(self, silent):
+        self.is_silent = silent
 
     def reset(self):
         """Remove all registered callbacks."""
@@ -65,9 +68,9 @@ class EventEmitter(object):
         """Prevent all callbacks to be called if events are raised
         in the context manager.
         """
-        self._is_silent = not(self._is_silent)
+        self.is_silent = not(self.is_silent)
         yield
-        self._is_silent = not(self._is_silent)
+        self.is_silent = not(self.is_silent)
 
     def connect(self, func=None, event=None, sender=None, **kwargs):
         """Register a callback function to a given event.
@@ -116,7 +119,7 @@ class EventEmitter(object):
         Return the list of callback return results.
 
         """
-        if self._is_silent:
+        if self.is_silent:
             return
         sender_name = sender.__class__.__name__
         logger.log(
@@ -301,4 +304,5 @@ emit = _EVENT.emit
 connect = _EVENT.connect
 unconnect = _EVENT.unconnect
 silent = _EVENT.silent
+set_silent = _EVENT.set_silent
 reset = _EVENT.reset

--- a/phylib/utils/event.py
+++ b/phylib/utils/event.py
@@ -47,6 +47,7 @@ class EventEmitter(object):
         self.is_silent = False
 
     def set_silent(self, silent):
+        """Set whether to silence the events."""
         self.is_silent = silent
 
     def reset(self):
@@ -157,6 +158,7 @@ class PartialFormatter(string.Formatter):
             return None, field_name
 
     def format_field(self, value, spec):
+        """Format a field."""
         if value is None:
             return '?'
         try:

--- a/phylib/utils/geometry.py
+++ b/phylib/utils/geometry.py
@@ -165,8 +165,7 @@ def _check_data_bounds(data_bounds):
 
 def _get_data_bounds(data_bounds, pos=None, length=None):
     """"Prepare data bounds, possibly using min/max of the data."""
-    if data_bounds is None or (isinstance(data_bounds, str) and
-                               data_bounds == 'auto'):
+    if data_bounds is None or (isinstance(data_bounds, str) and data_bounds == 'auto'):
         if pos is not None and len(pos):
             m, M = pos.min(axis=0), pos.max(axis=0)
             data_bounds = [m[0], m[1], M[0], M[1]]

--- a/phylib/utils/geometry.py
+++ b/phylib/utils/geometry.py
@@ -37,6 +37,7 @@ def staggered_positions(n_channels):
 #------------------------------------------------------------------------------
 
 def range_transform(from_bounds, to_bounds, positions):
+    """Transform for a rectangle to another."""
     from_bounds = np.asarray(from_bounds)
     to_bounds = np.asarray(to_bounds)
     positions = np.asarray(positions)
@@ -155,6 +156,7 @@ def _get_box_pos_size(box_bounds):
 
 
 def _check_data_bounds(data_bounds):
+    """Check that a data bounds is a valid."""
     assert data_bounds.ndim == 2
     assert data_bounds.shape[1] == 4
     assert np.all(data_bounds[:, 0] < data_bounds[:, 2])

--- a/phylib/utils/testing.py
+++ b/phylib/utils/testing.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 @contextmanager
 def captured_output():
+    """Context manager that captures all output to stdout and stderr."""
     new_out, new_err = StringIO(), StringIO()
     old_out, old_err = sys.stdout, sys.stderr
     try:
@@ -37,6 +38,7 @@ def captured_output():
 
 @contextmanager
 def captured_logging(name=None):
+    """Context manager that captures all logging."""
     logger = logging.getLogger(name)
     handlers = list(logger.handlers)
     for handler in logger.handlers:
@@ -72,4 +74,5 @@ def _assert_equal(d_0, d_1):
 
 
 def _in_travis():  # pragma: no cover
+    """Return whether we're in travis."""
     return 'TRAVIS' in os.environ

--- a/phylib/utils/tests/test_color.py
+++ b/phylib/utils/tests/test_color.py
@@ -86,7 +86,9 @@ def test_cluster_color_selector():
         assert colors.shape == (3, 4)
 
     # Get the state.
-    assert c.state == {'color_field': 'nonexisting', 'colormap': 'diverging', 'categorical': True}
+    assert c.state == {
+        'color_field': 'nonexisting', 'colormap': 'diverging',
+        'categorical': True, 'logarithmic': False}
 
     # Set the state.
     state = Bunch(c.state)
@@ -111,6 +113,17 @@ def test_cluster_color_group():
     )
 
     c.set_color_mapping(field='group', colormap='cluster_group')
+    colors = c.get_colors(cluster_ids)
+    assert colors.shape == (3, 4)
+
+
+def test_cluster_color_log():
+    cluster_ids = [1, 2, 3]
+    c = ClusterColorSelector(
+        cluster_ids=cluster_ids,
+    )
+
+    c.set_color_mapping(logarithmic=True)
     colors = c.get_colors(cluster_ids)
     assert colors.shape == (3, 4)
 

--- a/phylib/utils/tests/test_color.py
+++ b/phylib/utils/tests/test_color.py
@@ -76,12 +76,12 @@ def test_cluster_color_selector():
     assert len(c.get(1, alpha=.5)) == 4
     ae(c.get_values([None, 0]), np.arange(2))
 
-    for field, colormap in (
+    for color_field, colormap in (
             ('label', 'linear'),
             ('quality', 'rainbow'),
             ('cluster', 'categorical'),
             ('nonexisting', 'diverging')):
-        c.set_color_mapping(field=field, colormap=colormap)
+        c.set_color_mapping(color_field=color_field, colormap=colormap)
         colors = c.get_colors(cluster_ids)
         assert colors.shape == (3, 4)
 
@@ -112,7 +112,7 @@ def test_cluster_color_group():
         cluster_ids=cluster_ids,
     )
 
-    c.set_color_mapping(field='group', colormap='cluster_group')
+    c.set_color_mapping(color_field='group', colormap='cluster_group')
     colors = c.get_colors(cluster_ids)
     assert colors.shape == (3, 4)
 

--- a/phylib/utils/tests/test_color.py
+++ b/phylib/utils/tests/test_color.py
@@ -13,6 +13,7 @@ from numpy.testing import assert_almost_equal as ae
 from phylib.utils import Bunch
 from ..color import (
     _is_bright, _random_bright_color, spike_colors, add_alpha, selected_cluster_color,
+    _override_hsv,
     _hex_to_triplet, _continuous_colormap, _categorical_colormap, ClusterColorSelector,
     colormaps, _add_selected_clusters_colors)
 
@@ -36,6 +37,10 @@ def test_add_alpha():
 
     assert add_alpha((0, .5, 1, .1), .75) == (0, .5, 1, .75)
     assert add_alpha(np.random.rand(5, 4), .5).shape == (5, 4)
+
+
+def test_override_hsv():
+    assert _override_hsv((.1, .9, .5), h=1, s=0, v=1) == (1, 1, 1)
 
 
 def test_selected_cluster_color():

--- a/phylib/utils/tests/test_color.py
+++ b/phylib/utils/tests/test_color.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_almost_equal as ae
 
 from phylib.utils import Bunch
 from ..color import (
-    _is_bright, _random_bright_color, _spike_colors, add_alpha, selected_cluster_color,
+    _is_bright, _random_bright_color, spike_colors, add_alpha, selected_cluster_color,
     _hex_to_triplet, _continuous_colormap, _categorical_colormap, ClusterColorSelector,
     colormaps, _add_selected_clusters_colors)
 
@@ -44,15 +44,6 @@ def test_selected_cluster_color():
     assert len(c) == 4
 
 
-def test_spike_colors():
-    assert _spike_colors([0, 1, 10, 1000]).shape == (4, 4)
-    assert _spike_colors([0, 1, 10, 1000],
-                         alpha=1.).shape == (4, 4)
-    assert _spike_colors([0, 1, 10, 1000],
-                         masks=np.linspace(0., 1., 4)).shape == (4, 4)
-    assert _spike_colors(masks=np.linspace(0., 1., 4)).shape == (4, 4)
-
-
 def test_colormaps():
     colormap = np.array(cc.glasbey_bw_minc_20_minl_30)
     values = np.random.randint(10, 20, size=100)
@@ -63,6 +54,14 @@ def test_colormaps():
     values = np.linspace(0, 1, 100)
     colors = _continuous_colormap(colormap, values)
     assert colors.shape == (100, 3)
+
+
+def test_spike_colors():
+    spike_clusters = [1, 0, 0, 3]
+    cluster_ids = [0, 1, 2, 3]
+    colors = spike_colors(spike_clusters, cluster_ids)
+    assert colors.shape == (4, 4)
+    ae(colors[1], colors[2])
 
 
 def test_cluster_color_selector():

--- a/phylib/utils/tests/test_color.py
+++ b/phylib/utils/tests/test_color.py
@@ -34,6 +34,9 @@ def test_add_alpha():
     assert add_alpha((0, .5, 1), .75) == (0, .5, 1, .75)
     assert add_alpha(np.random.rand(5, 3), .5).shape == (5, 4)
 
+    assert add_alpha((0, .5, 1, .1), .75) == (0, .5, 1, .75)
+    assert add_alpha(np.random.rand(5, 4), .5).shape == (5, 4)
+
 
 def test_selected_cluster_color():
     c = selected_cluster_color(0)

--- a/phylib/utils/tests/test_color.py
+++ b/phylib/utils/tests/test_color.py
@@ -22,7 +22,7 @@ from ..color import (
 #------------------------------------------------------------------------------
 
 def test_random_color():
-    for _ in range(10):
+    for _ in range(20):
         assert _is_bright(_random_bright_color())
 
 

--- a/phylib/utils/tests/test_event.py
+++ b/phylib/utils/tests/test_event.py
@@ -55,6 +55,8 @@ def test_event_silent():
         ev.emit('test', ev, 1)
     assert _list == [1]
 
+    ev.set_silent(True)
+
 
 def test_event_single():
     ev = EventEmitter()

--- a/phylib/utils/tests/test_misc.py
+++ b/phylib/utils/tests/test_misc.py
@@ -12,7 +12,7 @@ from pytest import raises, mark
 
 from .._misc import (
     _git_version, load_json, save_json, load_pickle, save_pickle, read_python, read_text,
-    write_text, _read_tsv_simple, _write_tsv_simple, read_tsv, write_tsv,
+    write_text, _read_tsv_simple, _write_tsv_simple, read_tsv, write_tsv, _pretty_floats,
     _encode_qbytearray, _decode_qbytearray, _fullname, _load_from_fullname)
 
 
@@ -41,6 +41,12 @@ def test_qbytearray(tempdir):
     save_json(path, d)
     d_bis = load_json(path)
     assert d == d_bis
+
+
+def test_pretty_float():
+    assert _pretty_floats(0.123456) == '0.1235'
+    assert _pretty_floats([0.123456]) == ['0.1235']
+    assert _pretty_floats({'a': 0.123456}) == {'a': '0.1235'}
 
 
 def test_json_simple(tempdir):
@@ -111,8 +117,13 @@ def test_write_tsv(tempdir):
     write_tsv(path, [])
 
     data = [{'a': 1, 'b': 2}, {'a': 10}, {'b': 20, 'c': 30.5}]
-    write_tsv(path, data)
 
+    write_tsv(path, data)
+    assert read_tsv(path) == data
+
+    write_tsv(path, data, first_field='b', exclude_fields=('c', 'd'))
+    assert read_text(path)[0] == 'b'
+    del data[2]['c']
     assert read_tsv(path) == data
 
 

--- a/phylib/utils/tests/test_misc.py
+++ b/phylib/utils/tests/test_misc.py
@@ -10,18 +10,10 @@ import numpy as np
 from numpy.testing import assert_array_equal as ae
 from pytest import raises, mark
 
-from .._misc import (_git_version,
-                     _load_json, _save_json,
-                     _load_pickle, _save_pickle,
-                     _read_python,
-                     _read_text,
-                     _write_text,
-                     _read_tsv,
-                     _write_tsv,
-                     _encode_qbytearray, _decode_qbytearray,
-                     _fullname,
-                     _load_from_fullname,
-                     )
+from .._misc import (
+    _git_version, load_json, save_json, load_pickle, save_pickle, read_python, read_text,
+    write_text, _read_tsv, _write_tsv, _encode_qbytearray, _decode_qbytearray, _fullname,
+    _load_from_fullname)
 
 
 #------------------------------------------------------------------------------
@@ -46,8 +38,8 @@ def test_qbytearray(tempdir):
     # Test JSON serialization of QByteArray.
     d = {'arr': arr}
     path = tempdir / 'test'
-    _save_json(path, d)
-    d_bis = _load_json(path)
+    save_json(path, d)
+    d_bis = load_json(path)
     assert d == d_bis
 
 
@@ -55,14 +47,14 @@ def test_json_simple(tempdir):
     d = {'a': 1, 'b': 'bb', 3: '33', 'mock': {'mock': True}}
 
     path = tempdir / 'test_dir/test'
-    _save_json(path, d)
-    d_bis = _load_json(path)
+    save_json(path, d)
+    d_bis = load_json(path)
     assert d == d_bis
 
     path.write_text('')
-    assert _load_json(path) == {}
+    assert load_json(path) == {}
     with raises(IOError):
-        _load_json('%s_bis' % path)
+        load_json('%s_bis' % path)
 
 
 @mark.parametrize('kind', ['json', 'pickle'])
@@ -71,10 +63,10 @@ def test_json_numpy(tempdir, kind):
     d = {'a': arr, 'b': arr.ravel()[:10], 'c': arr[0, 0]}
 
     path = tempdir / 'test'
-    f = _save_json if kind == 'json' else _save_pickle
+    f = save_json if kind == 'json' else save_pickle
     f(path, d)
 
-    f = _load_json if kind == 'json' else _load_pickle
+    f = load_json if kind == 'json' else load_pickle
     d_bis = f(path)
     arr_bis = d_bis['a']
 
@@ -91,15 +83,15 @@ def test_read_python(tempdir):
     with open(path, 'w') as f:
         f.write("""a = {'b': 1}""")
 
-    assert _read_python(path) == {'a': {'b': 1}}
+    assert read_python(path) == {'a': {'b': 1}}
 
 
 def test_write_text(tempdir):
     for path in (tempdir / 'test_1',
                  tempdir / 'test_dir/test_2.txt',
                  ):
-        _write_text(path, 'hello world')
-        assert _read_text(path) == 'hello world'
+        write_text(path, 'hello world')
+        assert read_text(path) == 'hello world'
 
 
 def test_write_tsv(tempdir):

--- a/phylib/utils/tests/test_misc.py
+++ b/phylib/utils/tests/test_misc.py
@@ -12,8 +12,8 @@ from pytest import raises, mark
 
 from .._misc import (
     _git_version, load_json, save_json, load_pickle, save_pickle, read_python, read_text,
-    write_text, _read_tsv, _write_tsv, _encode_qbytearray, _decode_qbytearray, _fullname,
-    _load_from_fullname)
+    write_text, _read_tsv_simple, _write_tsv_simple, read_tsv, write_tsv,
+    _encode_qbytearray, _decode_qbytearray, _fullname, _load_from_fullname)
 
 
 #------------------------------------------------------------------------------
@@ -94,14 +94,26 @@ def test_write_text(tempdir):
         assert read_text(path) == 'hello world'
 
 
+def test_write_tsv_simple(tempdir):
+    path = tempdir / 'test.tsv'
+    assert _read_tsv_simple(path) == {}
+
+    # The read/write TSV functions conserve the types: int, float, or strings.
+    data = {2: 20, 3: 30.5, 5: 'hello'}
+    _write_tsv_simple(path, 'myfield', data)
+
+    assert _read_tsv_simple(path) == ('myfield', data)
+
+
 def test_write_tsv(tempdir):
     path = tempdir / 'test.tsv'
-    assert _read_tsv(path) == {}
+    assert read_tsv(path) == []
+    write_tsv(path, [])
 
-    data = {2: '20', 3: '30', 5: '50'}
-    _write_tsv(path, 'myfield', data)
+    data = [{'a': 1, 'b': 2}, {'a': 10}, {'b': 20, 'c': 30.5}]
+    write_tsv(path, data)
 
-    assert _read_tsv(path) == ('myfield', data)
+    assert read_tsv(path) == data
 
 
 def test_git_version():

--- a/phylib/utils/tests/test_misc.py
+++ b/phylib/utils/tests/test_misc.py
@@ -44,9 +44,9 @@ def test_qbytearray(tempdir):
 
 
 def test_pretty_float():
-    assert _pretty_floats(0.123456) == '0.1235'
-    assert _pretty_floats([0.123456]) == ['0.1235']
-    assert _pretty_floats({'a': 0.123456}) == {'a': '0.1235'}
+    assert _pretty_floats(0.123456) == '0.12'
+    assert _pretty_floats([0.123456]) == ['0.12']
+    assert _pretty_floats({'a': 0.123456}) == {'a': '0.12'}
 
 
 def test_json_simple(tempdir):

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,5 +24,6 @@ exclude_lines =
     except IOError:
     pass
     return$
+    continue$
 omit =
 show_missing = True


### PR DESCRIPTION
phylib alf extraction: need to squeeze matlab vectors to numpy vectors.
Matlab is agnostic to the difference of sizes [n, 1], [n]. Numpy is much more picky.
Output of KS2 comes from Matlab and vectors are saved in 2D arrays with a trailing dimension of 1.
They need to be converted to be consistent and easier to load and manipulate for client applications.