### PR TITLE
Fix for sparse export

### DIFF
--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -726,11 +726,14 @@ class TemplateModel(object):
         data, cols = self.sparse_templates.data, self.sparse_templates.cols
         assert cols is not None
         template_w, channel_ids = data[template_id], cols[template_id]
-        channel_ids = channel_ids.astype(np.uint32)
+        
         # Remove unused channels = -1.
         used = channel_ids != -1
         template_w = template_w[:, used]
         channel_ids = channel_ids[used]
+        
+        channel_ids = channel_ids.astype(np.uint32)
+
         # Unwhiten.
         template = self._unwhiten(template_w, channel_ids=channel_ids)
         template = template.astype(np.float32)


### PR DESCRIPTION
This slight change prevents a bug for sparse export. Converting the channels to uint32 before removing -1 is creating errors