### PR TITLE
Fix cluster indexing bug in merge probe

### DIFF
--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -174,7 +174,7 @@ class EphysAlfCreator(object):
     def make_cluster_waveforms(self):
         """Return the channel index with the highest template amplitude, for
         every template."""
-        peak_channel_path = self.dir_path / 'clusters.peakChannel.npy'
+        peak_channel_path = self.dir_path / 'clusters.channels.npy'
         if not peak_channel_path.exists():
             self._save_npy(peak_channel_path.name, self.model.templates_channels)
 
@@ -191,7 +191,7 @@ class EphysAlfCreator(object):
         assert spike_clusters.ndim == 1
         n_spikes = spike_clusters.shape[0]
 
-        cluster_channels = np.load(self.out_path / 'clusters.peakChannel.npy')
+        cluster_channels = np.load(self.out_path / 'clusters.channels.npy')
         assert cluster_channels.ndim == 1
         n_clusters = cluster_channels.shape[0]
 

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -125,7 +125,7 @@ class EphysAlfCreator(object):
             bar.update(10)
             self.make_spike_times()
             bar.update(10)
-            self.make_cluster_waveforms()
+            self.make_cluster_objects()
             bar.update(10)
             self.make_depths()
             bar.update(10)
@@ -171,9 +171,9 @@ class EphysAlfCreator(object):
         *samples*, and not in seconds."""
         self._save_npy('spikes.times.npy', self.model.spike_times)
 
-    def make_cluster_waveforms(self):
-        """Return the channel index with the highest template amplitude, for
-        every template."""
+    def make_cluster_objects(self):
+        """Create clusters.channels, clusters.waveformDuration and clusters.amps"""
+
         peak_channel_path = self.dir_path / 'clusters.channels.npy'
         if not peak_channel_path.exists():
             self._save_npy(peak_channel_path.name, self.model.templates_channels)
@@ -181,6 +181,10 @@ class EphysAlfCreator(object):
         waveform_duration_path = self.dir_path / 'clusters.waveformDuration.npy'
         if not waveform_duration_path.exists():
             self._save_npy(waveform_duration_path.name, self.model.templates_waveformDurations)
+
+        # group by average over cluster number
+        amps_path = self.dir_path / 'clusters.amps.npy'
+        self._save_npy(amps_path, self.model.templates_amplitudes)
 
     def make_depths(self):
         """Make spikes.depths.npy, clusters.depths.npy."""

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -183,8 +183,10 @@ class EphysAlfCreator(object):
             self._save_npy(waveform_duration_path.name, self.model.templates_waveforms_durations)
 
         # group by average over cluster number
+        camps = np.zeros(np.max(self.cluster_ids) - np.min(self.cluster_ids) + 1,) * np.nan
+        camps[self.cluster_ids - np.min(self.cluster_ids)] = self.model.templates_amplitudes
         amps_path = self.dir_path / 'clusters.amps.npy'
-        self._save_npy(amps_path, self.model.templates_amplitudes)
+        self._save_npy(amps_path.name, camps)
 
     def make_depths(self):
         """Make spikes.depths.npy, clusters.depths.npy."""

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -172,15 +172,15 @@ class EphysAlfCreator(object):
         self._save_npy('spikes.times.npy', self.model.spike_times)
 
     def make_cluster_objects(self):
-        """Create clusters.channels, clusters.waveformDuration and clusters.amps"""
+        """Create clusters.channels, clusters.waveformsDuration and clusters.amps"""
 
         peak_channel_path = self.dir_path / 'clusters.channels.npy'
         if not peak_channel_path.exists():
             self._save_npy(peak_channel_path.name, self.model.templates_channels)
 
-        waveform_duration_path = self.dir_path / 'clusters.waveformDuration.npy'
+        waveform_duration_path = self.dir_path / 'clusters.waveformsDuration.npy'
         if not waveform_duration_path.exists():
-            self._save_npy(waveform_duration_path.name, self.model.templates_waveformDurations)
+            self._save_npy(waveform_duration_path.name, self.model.templates_waveforms_durations)
 
         # group by average over cluster number
         amps_path = self.dir_path / 'clusters.amps.npy'

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -165,6 +165,7 @@ class EphysAlfCreator(object):
         """We cannot just rename/copy spike_times.npy because it is in unit of
         *samples*, and not in seconds."""
         self._save_npy('spikes.times.npy', self.model.spike_times)
+        self._save_npy('spikes.samples.npy', self.model.spike_samples)
 
     def make_cluster_objects(self):
         """Create clusters.channels, clusters.waveformsDuration and clusters.amps"""

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -37,19 +37,18 @@ logger = logging.getLogger(__name__)
 _FILE_RENAMES = [  # file_in, file_out, squeeze (bool to squeeze vector from matlab in npy)
     ('params.py', 'params.py', None),
     ('spike_clusters.npy', 'spikes.clusters.npy', True),
+    ('spike_templates.npy', 'spikes.templates.npy', True),
     ('amplitudes.npy', 'spikes.amps.npy', True),
     ('channel_positions.npy', 'channels.sitePositions.npy', False),
-    ('templates.npy', 'clusters.templateWaveforms.npy', False),
-    ('channel_map.npy', 'channels.rawRow.npy', True),
-    ('channel_map.npy', 'channels.rawRow.npy', True),
+    ('channel_map.npy', 'channels.rawInd.npy', True),
     ('channel_probe.npy', 'channels.probes.npy', True),
     ('cluster_probes.npy', 'clusters.probes.npy', True),
     ('cluster_shanks.npy', 'clusters.shanks.npy', True),
-
+    ('templates.npy', 'templates.waveforms.npy', False),
+    # ('cluster_ContamPct.tsv', 'clusters._ks2_contamication.tsv', False),
     # ('probes.description.txt', 'probes.description.txt', False),
-    # ('spike_templates.npy', 'ks2/spikes.clusters.npy', True),
-    # ('cluster_ContamPct.tsv', 'ks2/clusters.ContamPct.tsv', False),
     # ('cluster_group.tsv', 'ks2/clusters.phyAnnotation.tsv', False),
+
     # ('cluster_KSLabel.tsv', 'ks2/clusters.group.tsv', False),
 ]
 

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -27,19 +27,12 @@ logger = logging.getLogger(__name__)
 #------------------------------------------------------------------------------
 
 
-# ## TODO
-
-# probes.insertion
-# probes.sitePositions
-# probes.rawFilename
-# channels.brainLocation
-
 _FILE_RENAMES = [  # file_in, file_out, squeeze (bool to squeeze vector from matlab in npy)
     ('params.py', 'params.py', None),
     ('spike_clusters.npy', 'spikes.clusters.npy', True),
     ('spike_templates.npy', 'spikes.templates.npy', True),
     ('amplitudes.npy', 'spikes.amps.npy', True),
-    ('channel_positions.npy', 'channels.sitePositions.npy', False),
+    ('channel_positions.npy', 'channels.localCoordinates.npy', False),
     ('channel_map.npy', 'channels.rawInd.npy', True),
     ('channel_probe.npy', 'channels.probes.npy', True),
     ('cluster_probes.npy', 'clusters.probes.npy', True),

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -45,11 +45,10 @@ _FILE_RENAMES = [  # file_in, file_out, squeeze (bool to squeeze vector from mat
     ('cluster_probes.npy', 'clusters.probes.npy', True),
     ('cluster_shanks.npy', 'clusters.shanks.npy', True),
     ('templates.npy', 'templates.waveforms.npy', False),
-    # ('cluster_ContamPct.tsv', 'clusters._ks2_contamication.tsv', False),
-    # ('probes.description.txt', 'probes.description.txt', False),
-    # ('cluster_group.tsv', 'ks2/clusters.phyAnnotation.tsv', False),
-
-    # ('cluster_KSLabel.tsv', 'ks2/clusters.group.tsv', False),
+    # ('cluster_ContamPct.tsv', 'clusters._ks2_contamication.tsv', False), #Todo convert to numpy
+    # ('probes.description.txt', 'probes.description.txt', False), #
+    # ('cluster_group.tsv', 'ks2/clusters.phyAnnotation.tsv', False), # todo check indexing, add2QC
+    # ('cluster_KSLabel.tsv', 'ks2/clusters.group.tsv', False), # todo check indexing, add2QC
 ]
 
 FILE_DELETES = [

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -176,7 +176,7 @@ class EphysAlfCreator(object):
         if not peak_channel_path.exists():
             self._save_npy(peak_channel_path.name, self.model.templates_channels)
 
-        waveform_duration_path = self.dir_path / 'clusters.waveformsDuration.npy'
+        waveform_duration_path = self.dir_path / 'clusters.peakToThrough.npy'
         if not waveform_duration_path.exists():
             self._save_npy(waveform_duration_path.name, self.model.templates_waveforms_durations)
 

--- a/phylib/io/merge.py
+++ b/phylib/io/merge.py
@@ -139,16 +139,16 @@ class Merger(object):
         cluster_probes_l = []
         offset = 0
         for i, (subdir, sc) in enumerate(zip(self.subdirs, spike_clusters_l)):
+            n_clu = np.max(sc) + 1
             sc += offset
             self.cluster_offsets.append(offset)
-            # Number of clusters in each probe.
-            n_clu = len(np.unique(sc))
             cluster_probes_l.append(i * np.ones(n_clu, dtype=np.int32))
-            offset = sc.max() + 1
+            offset += n_clu
+
         spike_clusters = _load_multiple_spike_arrays(
             *spike_clusters_l, spike_order=self.spike_order)
         cluster_probes = _concat(cluster_probes_l)
-        assert len(np.unique(spike_clusters)) == len(cluster_probes)
+        assert np.max(spike_clusters) + 1 == cluster_probes.size
 
         self._save('spike_clusters.npy', spike_clusters)
         self._save('spike_templates.npy', spike_clusters)

--- a/phylib/io/merge.py
+++ b/phylib/io/merge.py
@@ -17,6 +17,7 @@ from scipy.linalg import block_diag
 from phylib.utils._misc import (
     _read_tsv_simple, _write_tsv_simple, write_tsv, read_python, write_python)
 from phylib.io.model import load_model
+from phylib.io.array import _index_of
 
 logger = logging.getLogger(__name__)
 
@@ -138,20 +139,20 @@ class Merger(object):
         self.cluster_offsets = []
         cluster_probes_l = []
         offset = 0
+        spike_clusters_l_out = []
         for i, (subdir, sc) in enumerate(zip(self.subdirs, spike_clusters_l)):
-            n_clu = np.max(sc) + 1
-            sc += offset
+            uc = np.unique(sc)
+            n_clu = uc.size
+            sc += n_clu
             self.cluster_offsets.append(offset)
             cluster_probes_l.append(i * np.ones(n_clu, dtype=np.int32))
+            spike_clusters_l_out.append(_index_of(sc, np.unique(sc)) + offset)
             offset += n_clu
-
         spike_clusters = _load_multiple_spike_arrays(
-            *spike_clusters_l, spike_order=self.spike_order)
+            *spike_clusters_l_out, spike_order=self.spike_order)
         cluster_probes = _concat(cluster_probes_l)
-        assert np.max(spike_clusters) + 1 == cluster_probes.size
-
+        assert np.unique(spike_clusters).size == cluster_probes.size
         self._save('spike_clusters.npy', spike_clusters)
-        self._save('spike_templates.npy', spike_clusters)
         self._save('cluster_probes.npy', cluster_probes)
 
     def write_cluster_data(self):

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -957,15 +957,16 @@ class TemplateModel(object):
         return a / n
 
     @property
-    def templates_waveformDurations(self):
-        """Returns a vector of waveform durations for all templates"""
+    def templates_waveforms_durations(self):
+        """Returns a vector of waveform durations (ms) for all templates"""
         tmp = self.sparse_templates.data
         n_templates, n_samples, n_channels = tmp.shape
         # Compute the peak channels for each template.
         template_peak_channels = np.argmax(tmp.max(axis=1) - tmp.min(axis=1), axis=1)
-        waveforms = tmp[:, :, template_peak_channels]
-        durations = waveforms.argmax(axis=1) - waveforms.argmin(axis=1)
-        return durations
+        durations = tmp.argmax(axis=1) - tmp.argmin(axis=1)
+        ind = np.ravel_multi_index((np.arange(0, n_templates), template_peak_channels),
+                                   (n_templates, n_channels), mode='raise', order='C')
+        return durations.flatten()[ind].astype(np.float64) / self.sample_rate * 1e3
 
     #--------------------------------------------------------------------------
     # Saving methods

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -468,7 +468,7 @@ class TemplateModel(object):
         return out
 
     def _load_channel_positions(self):
-        path = self._find_path('channel_positions.npy', 'channels.sitePositions.npy')
+        path = self._find_path('channel_positions.npy', 'channels.localCoordinates.npy')
         out = self._read_array(path)
         out = np.atleast_2d(out)
         assert out.ndim == 2

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -948,6 +948,15 @@ class TemplateModel(object):
         return self.channel_probes[self.templates_channels]
 
     @property
+    def templates_amplitudes(self):
+        """Returns the average amplitude per cluster"""
+        tid = np.unique(self.spike_templates)
+        n = np.bincount(self.spike_templates)[tid]
+        a = np.bincount(self.spike_templates, weights=self.amplitudes)[tid]
+        n[np.isnan(n)] = 1
+        return a / n
+
+    @property
     def templates_waveformDurations(self):
         """Returns a vector of waveform durations for all templates"""
         tmp = self.sparse_templates.data

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -578,7 +578,7 @@ class TemplateModel(object):
             path = self.dir_path / 'spikes.times.npy'
             logger.info("Loading spikes.times.npy in seconds, converting to samples.")
             spike_times = self._read_array(path)
-            out = (spike_times * self.sample_rate).astype(np.uint64)
+            out = np.round(spike_times * self.sample_rate).astype(np.uint64)
         assert out.ndim == 1
         return out
 

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -460,7 +460,7 @@ class TemplateModel(object):
         return spike_attributes
 
     def _load_channel_map(self):
-        path = self._find_path('channel_map.npy', 'channels.rawInd.npy')
+        path = self._find_path('channel_map.npy', 'channels._phy_ids.npy')
         out = self._read_array(path)
         out = np.atleast_1d(out)
         assert out.ndim == 1

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -464,7 +464,7 @@ class TemplateModel(object):
         return spike_attributes
 
     def _load_channel_map(self):
-        path = self._find_path('channel_map.npy', 'channels.rawRow.npy')
+        path = self._find_path('channel_map.npy', 'channels.rawInd.npy')
         out = self._read_array(path)
         out = np.atleast_1d(out)
         assert out.ndim == 1
@@ -596,7 +596,7 @@ class TemplateModel(object):
 
         # Sparse structure: regular array with col indices.
         try:
-            path = self._find_path('templates.npy', 'clusters.templateWaveforms.npy')
+            path = self._find_path('templates.npy', 'templates.waveforms.npy')
             data = self._read_array(path, mmap_mode='r')
             data = np.atleast_3d(data)
             assert data.ndim == 3

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -90,7 +90,6 @@ def test_creator(dataset):
         'spikes.depths.npy',
         'clusters.depths.npy',
         'clusters.meanWaveforms.npy',
-        # 'clusters.probes.npy',
     )
     path = Path(dataset.tmp_dir)
     out_path = path / 'alf'
@@ -111,4 +110,8 @@ def test_creator(dataset):
     for new in _FILE_CREATES:
         assert (out_path / new).exists()
 
-    model.close()
+    # makes sure the output dimensions match (especially clusters which should be 4)
+    cl_shape = [np.load(out_path / f).shape[0] for f in _FILE_CREATES if f.startswith('clusters.')]
+    sp_shape = [np.load(out_path / f).shape[0] for f in _FILE_CREATES if f.startswith('spikes.')]
+    assert len(set(cl_shape)) == 1
+    assert len(set(sp_shape)) == 1

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -85,10 +85,10 @@ def test_ephys_1(dataset):
 def test_creator(dataset):
     _FILE_CREATES = (
         'spikes.times.npy',
-        'clusters.peakChannel.npy',
         'clusters.waveformDuration.npy',
         'spikes.depths.npy',
         'clusters.depths.npy',
+        'clusters.channels.npy',
         'clusters.meanWaveforms.npy',
     )
     path = Path(dataset.tmp_dir)

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -91,6 +91,7 @@ def test_creator(dataset):
         'clusters.channels.npy',
         'clusters.meanWaveforms.npy',
         'clusters.amps.npy',
+        'channels.localCoordinates.npy',
     )
     path = Path(dataset.tmp_dir)
     out_path = path / 'alf'

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -87,6 +87,7 @@ def test_creator(dataset):
         'spikes.times.npy',
         'clusters.waveformsDuration.npy',
         'spikes.depths.npy',
+        'spikes.samples.npy',
         'clusters.depths.npy',
         'clusters.channels.npy',
         'clusters.meanWaveforms.npy',

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -90,6 +90,7 @@ def test_creator(dataset):
         'clusters.depths.npy',
         'clusters.channels.npy',
         'clusters.meanWaveforms.npy',
+        'clusters.amps.npy',
     )
     path = Path(dataset.tmp_dir)
     out_path = path / 'alf'

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -84,7 +84,7 @@ def test_ephys_1(dataset):
 def test_creator(dataset):
     _FILE_CREATES = (
         'spikes.times*.npy',
-        'clusters.waveformsDuration*.npy',
+        'clusters.peakToThrough*.npy',
         'spikes.depths*.npy',
         'spikes.samples*.npy',
         'clusters.depths*.npy',
@@ -126,7 +126,7 @@ def test_creator(dataset):
         assert len(set(sp_shape)) == 1
         assert len(set(ch_shape)) == 1
 
-        dur = np.load(next(out_path.glob('clusters.waveformsDuration*.npy')))
+        dur = np.load(next(out_path.glob('clusters.peakToThrough*.npy')))
         assert np.all(dur == np.array([-14., -24., -15., 8., -2.]) / 2)
 
     def read_after_write():

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -92,6 +92,8 @@ def test_creator(dataset):
         'clusters.meanWaveforms.npy',
         'clusters.amps.npy',
         'channels.localCoordinates.npy',
+        'channels.rawInd.npy',
+        'channels._phy_ids.npy',
     )
     path = Path(dataset.tmp_dir)
     out_path = path / 'alf'
@@ -115,8 +117,10 @@ def test_creator(dataset):
     # makes sure the output dimensions match (especially clusters which should be 4)
     cl_shape = [np.load(out_path / f).shape[0] for f in _FILE_CREATES if f.startswith('clusters.')]
     sp_shape = [np.load(out_path / f).shape[0] for f in _FILE_CREATES if f.startswith('spikes.')]
+    ch_shape = [np.load(out_path / f).shape[0] for f in _FILE_CREATES if f.startswith('channels.')]
     assert len(set(cl_shape)) == 1
     assert len(set(sp_shape)) == 1
+    assert len(set(ch_shape)) == 1
 
     dur = np.load(out_path / 'clusters.waveformsDuration.npy')
     assert np.all(dur == np.array([-14., -24., -15., 8., -2.]) / 2)

--- a/phylib/io/tests/test_alf.py
+++ b/phylib/io/tests/test_alf.py
@@ -85,7 +85,7 @@ def test_ephys_1(dataset):
 def test_creator(dataset):
     _FILE_CREATES = (
         'spikes.times.npy',
-        'clusters.waveformDuration.npy',
+        'clusters.waveformsDuration.npy',
         'spikes.depths.npy',
         'clusters.depths.npy',
         'clusters.channels.npy',
@@ -115,3 +115,6 @@ def test_creator(dataset):
     sp_shape = [np.load(out_path / f).shape[0] for f in _FILE_CREATES if f.startswith('spikes.')]
     assert len(set(cl_shape)) == 1
     assert len(set(sp_shape)) == 1
+
+    dur = np.load(out_path / 'clusters.waveformsDuration.npy')
+    assert np.all(dur == np.array([-14., -24., -15., 8., -2.]) / 2)

--- a/phylib/io/tests/test_merge.py
+++ b/phylib/io/tests/test_merge.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from ..merge import Merger
 from phylib.io.alf import EphysAlfCreator
-from phylib.io.array import _index_of
 from phylib.io.model import load_model
 from phylib.io.tests.conftest import _make_dataset
 
@@ -50,13 +49,16 @@ def test_probe_merge_2(tempdir):
     for name in probe_names:
         (tempdir / name).mkdir(exist_ok=True, parents=True)
         _make_dataset(tempdir / name, param='dense', has_spike_attributes=False)
+    subdirs = [tempdir / name for name in probe_names]
 
     # Add small shift in the spike times of the second probe.
     single = load_model(tempdir / probe_names[0] / 'params.py')
     st_path = tempdir / 'probe_right/spike_times.npy'
     np.save(st_path, single.spike_samples + 1)
-
-    subdirs = [tempdir / name for name in probe_names]
+    # make amplitudes unique and growing so they can serve as key and sorting indices
+    single.amplitudes = np.linspace(5, 15, single.n_spikes)
+    for m, subdir in enumerate(subdirs):
+        np.save(subdir / 'amplitudes.npy', single.amplitudes + 20 * m)
 
     # Merge them.
     m = Merger(subdirs, out_dir)
@@ -69,15 +71,25 @@ def test_probe_merge_2(tempdir):
 
     # Check the spikes.
     single = load_model(tempdir / probe_names[0] / 'params.py')
-    assert np.allclose(single.spike_times, merged.spike_times[::2])
-    assert np.allclose(merged.spike_times[1::2], single.spike_times + 4e-5)
+
+    def test_merged_single(merged):
+        _, im1, i1 = np.intersect1d(merged.amplitudes, single.amplitudes, return_indices=True)
+        _, im2, i2 = np.intersect1d(merged.amplitudes, single.amplitudes + 20, return_indices=True)
+        # intersection spans the full vector
+        assert i1.size + i2.size == merged.amplitudes.size
+        # test spikes
+        assert np.allclose(merged.spike_times[im1], single.spike_times[i1])
+        assert np.allclose(merged.spike_times[im2], single.spike_times[i2] + 4e-5)
+        assert np.allclose(merged.spike_clusters[im2], single.spike_clusters[i2] + 64)
+        assert np.allclose(merged.spike_clusters[im1], single.spike_clusters[i1])
+        # test clusters indices indexing via probes
+        spike_probes = merged.cluster_probes[merged.spike_clusters]
+        assert np.all(np.where(spike_probes == 0) == im1)
+        assert np.all(np.where(spike_probes == 1) == im2)
+        assert np.all(merged.amplitudes[spike_probes == 0] <= 15)
+        assert np.all(merged.amplitudes[spike_probes == 1] >= 20)
 
     # Convert into ALF and load.
     alf = EphysAlfCreator(merged).convert(tempdir / 'alf')
-
-    # Check that (almost) spike cluster probes are interleaved.
-    cluster_ids = np.unique(alf.spike_clusters)
-    sc_rel = _index_of(alf.spike_clusters, cluster_ids)
-    sp = alf.cluster_probes[sc_rel]
-    assert (sp[::2] != 0).sum() <= 1
-    assert (sp[1::2] != 1).sum() <= 1
+    test_merged_single(merged)
+    test_merged_single(alf)

--- a/phylib/io/tests/test_merge.py
+++ b/phylib/io/tests/test_merge.py
@@ -82,13 +82,18 @@ def test_probe_merge_2(tempdir):
         # test spikes
         assert np.allclose(merged.spike_times[im1], single.spike_times[i1])
         assert np.allclose(merged.spike_times[im2], single.spike_times[i2] + 4e-5)
-        # the empty clusters are discarded during the merge or alf export
+        # test clusters
         assert np.allclose(merged.spike_clusters[im2], single.spike_clusters[i2] + 64)
         assert np.allclose(merged.spike_clusters[im1], single.spike_clusters[i1])
-        # test clusters indices indexing via probes
+        # test templates
+        assert np.all(merged.spike_templates[im1] - single.spike_templates[i1] == 0)
+        assert np.all(merged.spike_templates[im2] - single.spike_templates[i2] == 64)
+        # test probes
+        assert np.all(merged.channel_probes == np.r_[single.channel_probes,
+                                                     single.channel_probes + 1])
+        assert np.all(merged.templates_channels[merged.templates_probes == 0] < single.n_channels)
+        assert np.all(merged.templates_channels[merged.templates_probes == 1] >= single.n_channels)
         spike_probes = merged.templates_probes[merged.spike_templates]
-        assert np.all(np.where(spike_probes == 0) == im1)
-        assert np.all(np.where(spike_probes == 1) == im2)
         assert np.all(merged.amplitudes[spike_probes == 0] <= 15)
         assert np.all(merged.amplitudes[spike_probes == 1] >= 20)
 

--- a/phylib/io/tests/test_merge.py
+++ b/phylib/io/tests/test_merge.py
@@ -13,6 +13,7 @@ from ..merge import Merger
 from phylib.io.alf import EphysAlfCreator
 from phylib.io.model import load_model
 from phylib.io.tests.conftest import _make_dataset
+from phylib.io.array import _index_of
 
 
 #------------------------------------------------------------------------------
@@ -80,8 +81,11 @@ def test_probe_merge_2(tempdir):
         # test spikes
         assert np.allclose(merged.spike_times[im1], single.spike_times[i1])
         assert np.allclose(merged.spike_times[im2], single.spike_times[i2] + 4e-5)
-        assert np.allclose(merged.spike_clusters[im2], single.spike_clusters[i2] + 64)
-        assert np.allclose(merged.spike_clusters[im1], single.spike_clusters[i1])
+        # the empty clusters are discarded during the merge or alf export
+        c1 = _index_of(single.spike_clusters[i1], np.unique(single.spike_clusters[i1]))
+        c2 = _index_of(single.spike_clusters[i2], np.unique(single.spike_clusters[i2]))
+        assert np.allclose(merged.spike_clusters[im2], c2 + 62)
+        assert np.allclose(merged.spike_clusters[im1], c1)
         # test clusters indices indexing via probes
         spike_probes = merged.cluster_probes[merged.spike_clusters]
         assert np.all(np.where(spike_probes == 0) == im1)

--- a/phylib/io/tests/test_merge.py
+++ b/phylib/io/tests/test_merge.py
@@ -102,6 +102,11 @@ def test_probe_merge_2(tempdir):
     test_merged_single(merged)
     test_merged_single(alf)
 
+    # specific test channel ids only for ALF merge dataset: the raw indices are still individual
+    # file indices, the merged channel mapping is in `channels._phy_ids.npy`
+    chid = np.load(tempdir.joinpath('alf', 'channels.rawInd.npy'))
+    assert np.all(chid == np.r_[single.channel_mapping, single.channel_mapping])
+
     out_files = list(tempdir.joinpath('alf').glob('*.*'))
     cl_shape = [np.load(f).shape[0] for f in out_files if f.name.startswith('clusters.')]
     sp_shape = [np.load(f).shape[0] for f in out_files if f.name.startswith('spikes.')]


### PR DESCRIPTION
This is essentially 2 bug fixes and associated tests:
1) The cluster_probes object didn't have the appropriate dimension. The reason was the indexing was only addressing clusters present in the current set of cluster_spikes, not all the orginal clusters
2) another issue was the direct casting to uint64 when converting spike times to spike samples which in effects performs a round down instead of a closest round. 
This is a potentially deeper issue if we consider spikes do not necessarily need to be assigned to an integer sample for various reasons (non-integer shift, clock-drift, parametric picking of spike time etc...)