### PR TITLE
Fix same_kind numpy multiplication

### DIFF
--- a/phylib/utils/geometry.py
+++ b/phylib/utils/geometry.py
@@ -63,7 +63,7 @@ def range_transform(from_bounds, to_bounds, positions, do_offset=True):
     out = positions.copy()
     if do_offset:
         out -= f0
-    out *= (t1 - t0) / d
+    out = out * ((t1 - t0) / d)
     if do_offset:
         out += t0
     return out

--- a/phylib/utils/geometry.py
+++ b/phylib/utils/geometry.py
@@ -62,10 +62,10 @@ def range_transform(from_bounds, to_bounds, positions, do_offset=True):
 
     out = positions.copy()
     if do_offset:
-        out -= f0
-    out = out * ((t1 - t0) / d)
+        out -= f0.astype(out.dtype)
+    out *= ((t1 - t0) / d).astype(out.dtype)
     if do_offset:
-        out += t0
+        out += t0.astype(out.dtype)
     return out
 
 


### PR DESCRIPTION
Hi @rossant 

In spikeinterface we export the channel positions as `float64` and this raises a `same_kind` exception with the new version of phy.

I was able to get rid of the error with this fix. Let me know if that works for you! I wasn't able to figure out another way.

Cheers
Alessio