### PR TITLE
Phylib not working with single channel templates

### DIFF
--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -621,9 +621,11 @@ class TemplateModel(object):
             # template_ind.npy (without an s).
             path = self._find_path('template_ind.npy', 'templates.waveformsChannels*.npy')
             cols = self._read_array(path)
-            cols = np.atleast_2d(cols)
+            if len(cols.shape) != 2:
+                cols = np.atleast_2d(cols).T
             assert cols.ndim == 2
             logger.debug("Templates are sparse.")
+
             assert cols.shape == (n_templates, n_channels_loc)
         except IOError:
             logger.debug("Templates are dense.")


### PR DESCRIPTION
Patch to allow phylib to work with 1D templates. Otherwise, the GUI is not working