### PR TITLE
Make default FlatEphysReader mode r instead of r+

### DIFF
--- a/phylib/io/traces.py
+++ b/phylib/io/traces.py
@@ -303,7 +303,7 @@ class BaseEphysReader(object):
 
 
 class FlatEphysReader(BaseEphysReader):
-    def __init__(self, paths, sample_rate=None, dtype=None, offset=0, n_channels=None, mode='r+',
+    def __init__(self, paths, sample_rate=None, dtype=None, offset=0, n_channels=None, mode='r',
                  **kwargs):
         super(FlatEphysReader, self).__init__()
         if isinstance(paths, (str, Path)):


### PR DESCRIPTION
Hi @rossant 

We are trying to run pykilosort via docker in SpikeInterface and the input folder are mapped with `r` mode. However, the  default mode of the `FlatEphysReader` is `r+`. Any reason why it is not read-only? 