### PR TITLE
Change `np.in1d` into `np.isin` as `np.in1d` will be deprecated with new versions of NumPy

### DIFF
--- a/phylib/io/array.py
+++ b/phylib/io/array.py
@@ -328,7 +328,7 @@ def _spikes_in_clusters(spike_clusters, clusters):
     """Return the ids of all spikes belonging to the specified clusters."""
     if len(spike_clusters) == 0 or len(clusters) == 0:
         return np.array([], dtype=int)
-    return np.nonzero(np.in1d(spike_clusters, clusters))[0]
+    return np.nonzero(np.isin(spike_clusters, clusters))[0]
 
 
 def _spikes_per_cluster(spike_clusters, spike_ids=None):

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -90,8 +90,8 @@ def from_sparse(data, cols, channel_ids):
     # NOTE: we ensure here that `col` contains integers.
     c = cols.flatten().astype(np.int32)
     # Remove columns that do not belong to the specified channels.
-    c[~np.in1d(c, channel_ids)] = -1
-    assert np.all(np.in1d(c, np.r_[channel_ids, -1]))
+    c[~np.isin(c, channel_ids)] = -1
+    assert np.all(np.isin(c, np.r_[channel_ids, -1]))
     # Convert column indices to relative indices given the specified
     # channel_ids.
     cols_loc = _index_of(c, np.r_[channel_ids, -1]).reshape(cols.shape)

--- a/phylib/io/tests/test_array.py
+++ b/phylib/io/tests/test_array.py
@@ -288,7 +288,7 @@ def test_spikes_in_clusters():
         assert np.all(spike_clusters[_spikes_in_clusters(spike_clusters, [i])] == i)
 
     clusters = [1, 2, 3]
-    assert np.all(np.in1d(
+    assert np.all(np.isin(
         spike_clusters[_spikes_in_clusters(spike_clusters, clusters)], clusters))
 
 

--- a/phylib/stats/tests/test_clusters.py
+++ b/phylib/stats/tests/test_clusters.py
@@ -103,7 +103,7 @@ def test_sorted_main_channels(masks):
     mean_masks = mean(masks)
     channels = get_sorted_main_channels(mean_masks,
                                         get_unmasked_channels(mean_masks))
-    assert np.all(np.in1d(channels, [5, 7]))
+    assert np.all(np.isin(channels, [5, 7]))
 
 
 def test_waveform_amplitude(masks, waveforms):


### PR DESCRIPTION
This is just to try to future-proof phylib since within a few releases this could lead to a hard error.
https://numpy.org/devdocs/release/2.0.0-notes.html
Then if this is approved it would either need a new pypi release or switching the build instruction for phy.