### PR TITLE
2.5.0

### DIFF
--- a/phylib/__init__.py
+++ b/phylib/__init__.py
@@ -9,10 +9,8 @@
 #------------------------------------------------------------------------------
 
 import atexit
-from io import StringIO
 import logging
 import os.path as op
-import sys
 
 from .utils._misc import _git_version
 from .utils.event import connect, unconnect, emit
@@ -24,7 +22,7 @@ from .utils.event import connect, unconnect, emit
 
 __author__ = 'Cyrille Rossant'
 __email__ = 'cyrille.rossant at gmail.com'
-__version__ = '2.4.3'
+__version__ = '2.5.0'
 __version_git__ = __version__ + _git_version()
 
 

--- a/phylib/io/alf.py
+++ b/phylib/io/alf.py
@@ -36,6 +36,7 @@ _FILE_RENAMES = [  # file_in, file_out, squeeze (bool to squeeze vector from mat
     ('spike_templates.npy', 'spikes.templates.npy', True),
     ('channel_positions.npy', 'channels.localCoordinates.npy', False),
     ('channel_probe.npy', 'channels.probes.npy', True),
+    ('channel_labels.npy', 'channels.labels.npy', True),
     ('cluster_probes.npy', 'clusters.probes.npy', True),
     ('cluster_shanks.npy', 'clusters.shanks.npy', True),
     ('whitening_mat.npy', '_kilosort_whitening.matrix.npy', False),

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -327,7 +327,6 @@ class TemplateModel(object):
         elif not isinstance(self.dat_path, (list, tuple)):
             self.dat_path = [self.dat_path]
         assert isinstance(self.dat_path, (list, tuple))
-        print(self.dat_path)
         self.dat_path = [Path(p).resolve() if not Path(p).is_symlink() else p for p in self.dat_path]
 
         self.dtype = getattr(self, 'dtype', np.int16)

--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -327,7 +327,8 @@ class TemplateModel(object):
         elif not isinstance(self.dat_path, (list, tuple)):
             self.dat_path = [self.dat_path]
         assert isinstance(self.dat_path, (list, tuple))
-        self.dat_path = [Path(_).resolve() for _ in self.dat_path]
+        print(self.dat_path)
+        self.dat_path = [Path(p).resolve() if not Path(p).is_symlink() else p for p in self.dat_path]
 
         self.dtype = getattr(self, 'dtype', np.int16)
         if not self.sample_rate:  # pragma: no cover


### PR DESCRIPTION
Changes related to spike sorting rerun:

-  `channels.labels.npy` support for pykilosort output
- When creating the `TemplateModel`, don't use `Path.resolve()` to resolve symlinks. (filenames have unique uuids inserted on SDSC cluster and symlinking with different filename is required)