### PR TITLE
Catch error on get spike waveform and try to get raw data

### DIFF
--- a/phylib/io/model.py
+++ b/phylib/io/model.py
@@ -970,9 +970,16 @@ class TemplateModel(object):
 
         if self.spike_waveforms is not None:
             # Load from precomputed spikes.
-            return get_spike_waveforms(
+            try:
+                return get_spike_waveforms(
                 spike_ids, channel_ids, spike_waveforms=self.spike_waveforms,
                 n_samples_waveforms=nsw)
+            except AssertionError:
+              logger.warning(
+                  "Error when loading waveforms from precomputed waveforms, trying to load the raw data.")
+              spike_samples = self.spike_samples[spike_ids]
+              return extract_waveforms(
+                  self.traces, spike_samples, channel_ids, n_samples_waveforms=nsw)
         else:
             # Or load directly from raw data (slower).
             spike_samples = self.spike_samples[spike_ids]


### PR DESCRIPTION
This pull request improves the error handling mechanism when loading spike waveforms from precomputed data. 
Previously, the code would directly load the spike waveforms if available, or fallback to extracting waveforms from raw data if precomputed waveforms were not present. 

The enhancement includes a try-except block to handle potential errors during the loading of precomputed waveforms, ensuring a more robust and fail-safe execution.